### PR TITLE
Added static casts of `size_t` container sizes

### DIFF
--- a/src/component_pool.hpp
+++ b/src/component_pool.hpp
@@ -50,11 +50,11 @@ public:
     }
 
     size_type capacity() const noexcept {
-        return data.capacity();
+        return static_cast<size_type>(data.capacity());
     }
 
     size_type size() const noexcept {
-        return data.size();
+        return static_cast<size_type>(data.size());
     }
 
     const entity_type * entities() const noexcept {
@@ -82,7 +82,7 @@ public:
             reverse.resize(entity+1);
         }
 
-        reverse[entity] = direct.size();
+        reverse[entity] = static_cast<size_type>(direct.size());
         direct.emplace_back(entity);
         data.push_back({ args... });
 

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -246,11 +246,11 @@ public:
     Registry & operator=(Registry &&) = delete;
 
     size_type size() const noexcept {
-        return count - available.size();
+        return static_cast<size_type>(count - static_cast<entity_type>(available.size()));
     }
 
     size_type capacity() const noexcept {
-        return count;
+        return static_cast<size_type>(count);
     }
 
     template<typename Comp>


### PR DESCRIPTION
Previously `size_t` values returned by the internal containers were implicitly converted to the ECS `size_type` which results in compiler warnings about possible loss of accuracy (if `size_type` < `size_t`). If you want to make the user aware of this issue, I would rather add an assert in the `create()` method or something like this.