### PR TITLE
Remove final specifier from all class templates

### DIFF
--- a/src/component_pool.hpp
+++ b/src/component_pool.hpp
@@ -20,7 +20,7 @@ class ComponentPool;
 
 
 template<typename Entity, typename Component>
-class ComponentPool<Entity, Component> final {
+class ComponentPool<Entity, Component> {
 public:
     using component_type = Component;
     using size_type = std::uint32_t;
@@ -116,7 +116,7 @@ private:
 
 
 template<typename Entity, typename Component, typename... Components>
-class ComponentPool final {
+class ComponentPool {
     template<typename Comp>
     using Pool = ComponentPool<Entity, Comp>;
 

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -20,7 +20,7 @@ class View;
 
 
 template<template<typename...> class Pool, typename Entity, typename... Components, typename Type, typename... Types>
-class View<Pool<Entity, Components...>, Type, Types...> {
+class View<Pool<Entity, Components...>, Type, Types...> final {
     using pool_type = Pool<Entity, Components...>;
     using entity_type = typename pool_type::entity_type;
 
@@ -122,7 +122,7 @@ private:
 
 
 template<template<typename...> class Pool, typename Entity, typename... Components, typename Type>
-class View<Pool<Entity, Components...>, Type> {
+class View<Pool<Entity, Components...>, Type> final {
     using pool_type = Pool<Entity, Components...>;
     using entity_type = typename pool_type::entity_type;
 

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -20,7 +20,7 @@ class View;
 
 
 template<template<typename...> class Pool, typename Entity, typename... Components, typename Type, typename... Types>
-class View<Pool<Entity, Components...>, Type, Types...> final {
+class View<Pool<Entity, Components...>, Type, Types...> {
     using pool_type = Pool<Entity, Components...>;
     using entity_type = typename pool_type::entity_type;
 
@@ -122,7 +122,7 @@ private:
 
 
 template<template<typename...> class Pool, typename Entity, typename... Components, typename Type>
-class View<Pool<Entity, Components...>, Type> final {
+class View<Pool<Entity, Components...>, Type> {
     using pool_type = Pool<Entity, Components...>;
     using entity_type = typename pool_type::entity_type;
 
@@ -192,7 +192,7 @@ class Registry;
 
 
 template<template<typename...> class Pool, typename Entity, typename... Components>
-class Registry<Pool<Entity, Components...>> final {
+class Registry<Pool<Entity, Components...>> {
     using pool_type = Pool<Entity, Components...>;
 
 public:


### PR DESCRIPTION
All class templates from the ECS are defined as `final`. In my opinion this is not sensible. In my concrete application I want to be able to forward declare the ECS class without retyping all template parameters (forward declaration of typedefs is not possible). The easiest way to do this would be to inherit from the EnTT types:
```
class EntityComponentSystem : public entt::StandardRegistry<EntityType, ...> {/* stays empty */};
```
now I can forward declare the `EntityComponentSystem` class in other parts of the project.

In general I don't see an advantage of using `final` in this context and I would propose to remove the  specifiers from the headers.