### PR TITLE
Fix MSVC 2017 warning C4458

### DIFF
--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -614,11 +614,11 @@ public:
         auto to = other.end();
 
         pos_type pos = underlying_type::size() - 1;
-        const auto *directEntity = underlying_type::data();
+        const auto *local = underlying_type::data();
 
         while(pos > 0 && from != to) {
             if(underlying_type::has(*from)) {
-                if(*from != *(directEntity + pos)) {
+                if(*from != *(local + pos)) {
                     auto candidate = underlying_type::get(*from);
                     std::swap(instances[pos], instances[candidate]);
                     underlying_type::swap(pos, candidate);

--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -614,11 +614,11 @@ public:
         auto to = other.end();
 
         pos_type pos = underlying_type::size() - 1;
-        const auto *direct = underlying_type::data();
+        const auto *directEntity = underlying_type::data();
 
         while(pos > 0 && from != to) {
             if(underlying_type::has(*from)) {
-                if(*from != *(direct + pos)) {
+                if(*from != *(directEntity + pos)) {
                     auto candidate = underlying_type::get(*from);
                     std::swap(instances[pos], instances[candidate]);
                     underlying_type::swap(pos, candidate);


### PR DESCRIPTION
src\entt\entity\sparse_set.hpp(617): warning C4458: declaration of 'direct' hides class member
Only triggered by /W4. The rest of the library compiles fine so might as well fix this one :)
Just renaming temporary variable. Wasn't exactly sure of a correct name.