### PR TITLE
Add Dispatcher header to EnTT global include

### DIFF
--- a/src/entt/entt.hpp
+++ b/src/entt/entt.hpp
@@ -14,7 +14,7 @@
 #include "resource/loader.hpp"
 #include "signal/bus.hpp"
 #include "signal/delegate.hpp"
+#include "signal/dispatcher.hpp"
 #include "signal/emitter.hpp"
 #include "signal/sigh.hpp"
 #include "signal/signal.hpp"
-#include "signal/dispatcher.hpp"

--- a/src/entt/entt.hpp
+++ b/src/entt/entt.hpp
@@ -17,3 +17,4 @@
 #include "signal/emitter.hpp"
 #include "signal/sigh.hpp"
 #include "signal/signal.hpp"
+#include "signal/dispatcher.hpp"


### PR DESCRIPTION
Or is there a reason why it is not included?