### PR TITLE
Implement entt::Prototype

### DIFF
--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -198,7 +198,7 @@ public:
     /**
      * @brief Assigns of replaces the given component
      *
-     * @tparam Comp Type of component to replace
+     * @tparam Component Type of component to replace
      * @tparam Args Types of arguments to use to construct the component
      * @param args Parameters to use to initialize the component
      * @return A refernce to the newly created component

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -3,6 +3,21 @@
 
 #include "registry.hpp"
 
+namespace entt {
+
+/**
+ * @brief A prototype entity for creating new entities
+ *
+ * Prototype provides a similar interface to the registry except that Prototype
+ * stores a single entity. This entity is not apart of the registry so it is not
+ * seen by views. The Prototype can be used to accommodate components to an
+ * entity on the registry.
+ *
+ * Note that components stored in the Prototype must have copy constructors to
+ * initialize an entity.
+ *
+ * @tparam Entity A valid entity type (see entt_traits for more details).
+ */
 template <typename Entity>
 class Prototype {
 public:
@@ -14,14 +29,14 @@ private:
   class ComponentBase {
   public:
     virtual ~ComponentBase() = default;
-    virtual void assign(registry_t &, entity_t) const = 0;
+    virtual void accommodate(registry_t &, entity_t) const ENTT_NOEXCEPT = 0;
   };
   
   template <typename Comp>
   class Component : public ComponentBase {
   public:
-    void assign(registry_t &registry, const entity_t entity) const override {
-      registry.template accommodate<Comp>(entity, comp);
+    void accommodate(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT override {
+      reg.template accommodate<Comp>(entity, comp);
     }
     
     Comp comp;
@@ -32,28 +47,61 @@ public:
   Prototype(Prototype &&) = default;
   Prototype &operator=(Prototype &&) = default;
 
+  /**
+   * @brief Checks if there exists at least one component assigned
+   *
+   * @return True if at least one component is assigned
+   */
   bool empty() const ENTT_NOEXCEPT {
     return comps.empty();
   }
 
+  /**
+   * @brief Accommodate copies of the components to the given entity
+   */
   void operator()(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT {
     for (const std::unique_ptr<ComponentBase> &component : comps) {
       if (component) {
-        component->assign(reg, entity);
+        component->accommodate(reg, entity);
       }
     }
   }
+  /**
+   * @brief Create an new entity assign copies of the components to it
+   *
+   * @return Newly created entity
+   */
   entity_t operator()(registry_t &reg) const ENTT_NOEXCEPT {
     const entity_t entity = reg.create();
     (*this)(reg, entity);
     return entity;
   }
 
+  /**
+   * @brief Returns the numeric identifier of a type of component at runtime
+   *
+   * The component doesn't need to be assigned to the prototype for this
+   * function to return a valid ID. The IDs are not synced with the registry.
+   *
+   * @tparam Comp Type of component to query.
+   * @return Runtime numeric identifier of the given type of component
+   */
   template <typename Comp>
   size_t type() const ENTT_NOEXCEPT {
     return family_t::template type<Comp>();
   }
 
+  /**
+   * @brief Assigns the given component to the prototype
+   *
+   * @warning
+   * An assertion will abort the execution at runtime in debug mode in case
+   * the prototype already owns the given component
+   *
+   * @tparam Comp Type of component to create
+   * @tparam Args Types of arguments to use to construct the component.
+   * @return A reference to the newly created component.
+   */
   template <typename Comp, typename ...Args>
   Comp &assign(Args &&... args) {
     assert(!has<Comp>());
@@ -68,24 +116,61 @@ public:
     return comp;
   }
   
+  /**
+   * @brief Removes the given component from the prototype
+   *
+   * @warning
+   * An assertion will abort the execution at runtime in debug mode in case
+   * the prototype doesn't own the given component
+   *
+   * @tparam Comp Type of component to remove
+   */
   template <typename Comp>
   void remove() ENTT_NOEXCEPT {
     assert(has<Comp>());
     comps[type<Comp>()] = nullptr;
   }
   
-  template <typename Comp>
+  /**
+   * @brief Checks if the prototype has all the given components
+   *
+   * @tparam Comp Components that the prototype must own
+   * @return True if the prototype owns all of the components, false otherwise.
+   */
+  template <typename... Comp>
   bool has() const ENTT_NOEXCEPT {
-    const size_t index = type<Comp>();
-    return index < comps.size() && comps[index] != nullptr;
+    bool all = true;
+    [[maybe_unused]]
+    bool acc[] = {(all = all && type<Comp>() < comps.size() && comps[type<Comp>()] != nullptr)...};
+    return all;
   }
   
+  /**
+   * @brief Returns a const reference to the given component
+   *
+   * @warning
+   * An assertion will abort the execution at runtime in debug mode in case
+   * the prototype doesn't own the given component
+   *
+   * @tparam Comp Type of component to get
+   * @return A reference to the component
+   */
   template <typename Comp>
   const Comp &get() const ENTT_NOEXCEPT {
     assert(has<Comp>());
     return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
   }
   
+  /**
+   * @brief Returns a reference to the given component
+   *
+   * @warning
+   * An assertion will abort the execution at runtime in debug mode in case
+   * the prototype doesn't own the given component
+   *
+   * @tparam Comp Type of component to get
+   * @return A reference to the component
+   */
   template <typename Comp>
   Comp &get() ENTT_NOEXCEPT {
     assert(has<Comp>());
@@ -95,5 +180,7 @@ public:
 private:
   std::vector<std::unique_ptr<ComponentBase>> comps;
 };
+
+}
 
 #endif

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -21,199 +21,199 @@ namespace entt {
 template <typename Entity>
 class Prototype {
 public:
-  using entity_t = Entity;
-  using registry_t = entt::Registry<Entity>;
-  using family_t = entt::Family<struct PrototypeFamily>;
+    using entity_t = Entity;
+    using registry_t = entt::Registry<Entity>;
+    using family_t = entt::Family<struct PrototypeFamily>;
 
 private:
-  struct StorageBase {
-    virtual ~StorageBase() = default;
-    virtual void accommodate(registry_t &, entity_t) const ENTT_NOEXCEPT = 0;
-  };
-  
-  template <typename Component>
-  struct Storage : StorageBase {
-    void accommodate(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT override {
-      reg.template accommodate<Component>(entity, comp);
-    }
+    struct StorageBase {
+        virtual ~StorageBase() = default;
+        virtual void accommodate(registry_t &, entity_t) const ENTT_NOEXCEPT = 0;
+    };
     
-    Component comp;
-  };
+    template <typename Component>
+    struct Storage : StorageBase {
+        void accommodate(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT override {
+            reg.template accommodate<Component>(entity, comp);
+        }
+        
+        Component comp;
+    };
 
 public:
-  Prototype() = default;
-  Prototype(Prototype &&) = default;
-  Prototype &operator=(Prototype &&) = default;
+    Prototype() = default;
+    Prototype(Prototype &&) = default;
+    Prototype &operator=(Prototype &&) = default;
 
-  /**
-   * @brief Checks if there exists at least one component assigned
-   *
-   * @return True if at least one component is assigned
-   */
-  bool empty() const ENTT_NOEXCEPT {
-    return std::all_of(comps.cbegin(), comps.cend(), [] (auto comp) {
-      return comp == nullptr;
-    });
-  }
-
-  /**
-   * @brief Accommodate copies of the components to the given entity
-   */
-  void operator()(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT {
-    for (const std::unique_ptr<StorageBase> &component : comps) {
-      if (component) {
-        component->accommodate(reg, entity);
-      }
+    /**
+     * @brief Checks if there exists at least one component assigned
+     *
+     * @return True if at least one component is assigned
+     */
+    bool empty() const ENTT_NOEXCEPT {
+        return std::all_of(comps.cbegin(), comps.cend(), [] (auto comp) {
+            return comp == nullptr;
+        });
     }
-  }
-  /**
-   * @brief Create an new entity assign copies of the components to it
-   *
-   * @return Newly created entity
-   */
-  entity_t operator()(registry_t &reg) const ENTT_NOEXCEPT {
-    const entity_t entity = reg.create();
-    (*this)(reg, entity);
-    return entity;
-  }
 
-  /**
-   * @brief Returns the numeric identifier of a type of component at runtime
-   *
-   * The component doesn't need to be assigned to the prototype for this
-   * function to return a valid ID. The IDs are not synced with the registry.
-   *
-   * @tparam Component Type of component to query.
-   * @return Runtime numeric identifier of the given type of component
-   */
-  template <typename Component>
-  size_t type() const ENTT_NOEXCEPT {
-    return family_t::template type<Component>();
-  }
+    /**
+     * @brief Accommodate copies of the components to the given entity
+     */
+    void operator()(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT {
+        for (const std::unique_ptr<StorageBase> &component : comps) {
+            if (component) {
+                component->accommodate(reg, entity);
+            }
+        }
+    }
+    /**
+     * @brief Create an new entity assign copies of the components to it
+     *
+     * @return Newly created entity
+     */
+    entity_t operator()(registry_t &reg) const ENTT_NOEXCEPT {
+        const entity_t entity = reg.create();
+        (*this)(reg, entity);
+        return entity;
+    }
 
-  /**
-   * @brief Assigns the given component to the prototype
-   *
-   * @warning
-   * An assertion will abort the execution at runtime in debug mode in case
-   * the prototype already owns the given component
-   *
-   * @tparam Component Type of component to create
-   * @tparam Args Types of arguments to use to construct the component.
-   * @param args Parameters to use to initialize the component.
-   * @return A reference to the newly created component.
-   */
-  template <typename Component, typename... Args>
-  Component &assign(Args &&... args) {
-    assert(!has<Component>());
-    auto component = std::make_unique<Storage<Component>>();
-    component->comp = Component {std::forward<Args>(args)...};
-    const size_t index = type<Component>();
-    while (comps.size() <= index) {
-      comps.emplace_back();
+    /**
+     * @brief Returns the numeric identifier of a type of component at runtime
+     *
+     * The component doesn't need to be assigned to the prototype for this
+     * function to return a valid ID. The IDs are not synced with the registry.
+     *
+     * @tparam Component Type of component to query.
+     * @return Runtime numeric identifier of the given type of component
+     */
+    template <typename Component>
+    size_t type() const ENTT_NOEXCEPT {
+        return family_t::template type<Component>();
     }
-    Component &comp = component->comp;
-    comps[index] = std::move(component);
-    return comp;
-  }
-  
-  /**
-   * @brief Removes the given component from the prototype
-   *
-   * @warning
-   * An assertion will abort the execution at runtime in debug mode in case
-   * the prototype doesn't own the given component
-   *
-   * @tparam Component Type of component to remove
-   */
-  template <typename Component>
-  void remove() ENTT_NOEXCEPT {
-    assert(has<Component>());
-    comps[type<Component>()] = nullptr;
-  }
-  
-  /**
-   * @brief Checks if the prototype has all the given components
-   *
-   * @tparam Components Components that the prototype must own
-   * @return True if the prototype owns all of the components, false otherwise.
-   */
-  template <typename... Components>
-  bool has() const ENTT_NOEXCEPT {
-    bool all = true;
-    [[maybe_unused]]
-    bool acc[] = {(all = all && type<Components>() < comps.size() && comps[type<Components>()] != nullptr)...};
-    return all;
-  }
-  
-  /**
-   * @brief Returns a const reference to the given component
-   *
-   * @warning
-   * An assertion will abort the execution at runtime in debug mode in case
-   * the prototype doesn't own the given component
-   *
-   * @tparam Component Type of component to get
-   * @return A reference to the component
-   */
-  template <typename Component>
-  const Component &get() const ENTT_NOEXCEPT {
-    assert(has<Component>());
-    return static_cast<Storage<Component> *>(comps[type<Component>()].get())->comp;
-  }
-  
-  /**
-   * @brief Returns a reference to the given component
-   *
-   * @warning
-   * An assertion will abort the execution at runtime in debug mode in case
-   * the prototype doesn't own the given component
-   *
-   * @tparam Component Type of component to get
-   * @return A reference to the component
-   */
-  template <typename Component>
-  Component &get() ENTT_NOEXCEPT {
-    assert(has<Component>());
-    return static_cast<Storage<Component> *>(comps[type<Component>()].get())->comp;
-  }
-  
-  /**
-   * @brief Replaces the given component
-   *
-   * @warning
-   * An assertion will abort the execution at runtime in debug mode in case
-   * the prototype doesn't own the given component
-   *
-   * @tparam Component Type of component to replace
-   * @tparam Args Types of arguments to use to construct the component
-   * @param args Parameters to use to initialize the component
-   * @return A refernce to the newly created component
-   */
-  template <typename Component, typename... Args>
-  Component &replace(Args &&... args) ENTT_NOEXCEPT {
-    return (get<Component>() = Component{std::forward<Args>(args)...});
-  }
-  
-  /**
-   * @brief Assigns of replaces the given component
-   *
-   * @tparam Comp Type of component to replace
-   * @tparam Args Types of arguments to use to construct the component
-   * @param args Parameters to use to initialize the component
-   * @return A refernce to the newly created component
-   */
-  template <typename Component, typename... Args>
-  Component &accommodate(Args &&... args) ENTT_NOEXCEPT {
-    if (has<Component>()) {
-      return replace<Component>(std::forward<Args>(args)...);
-    } else {
-      return assign<Component>(std::forward<Args>(args)...);
+
+    /**
+     * @brief Assigns the given component to the prototype
+     *
+     * @warning
+     * An assertion will abort the execution at runtime in debug mode in case
+     * the prototype already owns the given component
+     *
+     * @tparam Component Type of component to create
+     * @tparam Args Types of arguments to use to construct the component.
+     * @param args Parameters to use to initialize the component.
+     * @return A reference to the newly created component.
+     */
+    template <typename Component, typename... Args>
+    Component &assign(Args &&... args) {
+        assert(!has<Component>());
+        auto component = std::make_unique<Storage<Component>>();
+        component->comp = Component {std::forward<Args>(args)...};
+        const size_t index = type<Component>();
+        while (comps.size() <= index) {
+            comps.emplace_back();
+        }
+        Component &comp = component->comp;
+        comps[index] = std::move(component);
+        return comp;
     }
-  }
-  
+    
+    /**
+     * @brief Removes the given component from the prototype
+     *
+     * @warning
+     * An assertion will abort the execution at runtime in debug mode in case
+     * the prototype doesn't own the given component
+     *
+     * @tparam Component Type of component to remove
+     */
+    template <typename Component>
+    void remove() ENTT_NOEXCEPT {
+        assert(has<Component>());
+        comps[type<Component>()] = nullptr;
+    }
+    
+    /**
+     * @brief Checks if the prototype has all the given components
+     *
+     * @tparam Components Components that the prototype must own
+     * @return True if the prototype owns all of the components, false otherwise.
+     */
+    template <typename... Components>
+    bool has() const ENTT_NOEXCEPT {
+        bool all = true;
+        [[maybe_unused]]
+        bool acc[] = {(all = all && type<Components>() < comps.size() && comps[type<Components>()] != nullptr)...};
+        return all;
+    }
+    
+    /**
+     * @brief Returns a const reference to the given component
+     *
+     * @warning
+     * An assertion will abort the execution at runtime in debug mode in case
+     * the prototype doesn't own the given component
+     *
+     * @tparam Component Type of component to get
+     * @return A reference to the component
+     */
+    template <typename Component>
+    const Component &get() const ENTT_NOEXCEPT {
+        assert(has<Component>());
+        return static_cast<Storage<Component> *>(comps[type<Component>()].get())->comp;
+    }
+    
+    /**
+     * @brief Returns a reference to the given component
+     *
+     * @warning
+     * An assertion will abort the execution at runtime in debug mode in case
+     * the prototype doesn't own the given component
+     *
+     * @tparam Component Type of component to get
+     * @return A reference to the component
+     */
+    template <typename Component>
+    Component &get() ENTT_NOEXCEPT {
+        assert(has<Component>());
+        return static_cast<Storage<Component> *>(comps[type<Component>()].get())->comp;
+    }
+    
+    /**
+     * @brief Replaces the given component
+     *
+     * @warning
+     * An assertion will abort the execution at runtime in debug mode in case
+     * the prototype doesn't own the given component
+     *
+     * @tparam Component Type of component to replace
+     * @tparam Args Types of arguments to use to construct the component
+     * @param args Parameters to use to initialize the component
+     * @return A refernce to the newly created component
+     */
+    template <typename Component, typename... Args>
+    Component &replace(Args &&... args) ENTT_NOEXCEPT {
+        return (get<Component>() = Component{std::forward<Args>(args)...});
+    }
+    
+    /**
+     * @brief Assigns of replaces the given component
+     *
+     * @tparam Comp Type of component to replace
+     * @tparam Args Types of arguments to use to construct the component
+     * @param args Parameters to use to initialize the component
+     * @return A refernce to the newly created component
+     */
+    template <typename Component, typename... Args>
+    Component &accommodate(Args &&... args) ENTT_NOEXCEPT {
+        if (has<Component>()) {
+            return replace<Component>(std::forward<Args>(args)...);
+        } else {
+            return assign<Component>(std::forward<Args>(args)...);
+        }
+    }
+    
 private:
-  std::vector<std::unique_ptr<StorageBase>> comps;
+    std::vector<std::unique_ptr<StorageBase>> comps;
 };
 
 /**

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -32,21 +32,25 @@ public:
   Prototype(Prototype &&) = default;
   Prototype &operator=(Prototype &&) = default;
 
-  void operator()(registry_t &reg, const entity_t entity) const {
+  bool empty() const ENTT_NOEXCEPT {
+    return comps.empty();
+  }
+
+  void operator()(registry_t &reg, const entity_t entity) const ENTT_NOEXCEPT {
     for (const std::unique_ptr<ComponentBase> &component : comps) {
       if (component) {
         component->assign(reg, entity);
       }
     }
   }
-  entity_t operator()(registry_t &reg) const {
+  entity_t operator()(registry_t &reg) const ENTT_NOEXCEPT {
     const entity_t entity = reg.create();
     (*this)(reg, entity);
     return entity;
   }
 
   template <typename Comp>
-  size_t type() const {
+  size_t type() const ENTT_NOEXCEPT {
     return family_t::template type<Comp>();
   }
 
@@ -65,25 +69,25 @@ public:
   }
   
   template <typename Comp>
-  void remove() {
+  void remove() ENTT_NOEXCEPT {
     assert(has<Comp>());
     comps[type<Comp>()] = nullptr;
   }
   
   template <typename Comp>
-  bool has() const {
+  bool has() const ENTT_NOEXCEPT {
     const size_t index = type<Comp>();
     return index < comps.size() && comps[index] != nullptr;
   }
   
   template <typename Comp>
-  const Comp &get() const {
+  const Comp &get() const ENTT_NOEXCEPT {
     assert(has<Comp>());
     return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
   }
   
   template <typename Comp>
-  Comp &get() {
+  Comp &get() ENTT_NOEXCEPT {
     assert(has<Comp>());
     return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
   }

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -216,6 +216,11 @@ private:
   std::vector<std::unique_ptr<StorageBase>> comps;
 };
 
+/**
+ * @brief Default prototype
+ */
+using DefaultPrototype = Prototype<uint32_t>;
+
 }
 
 #endif

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -100,9 +100,10 @@ public:
    *
    * @tparam Comp Type of component to create
    * @tparam Args Types of arguments to use to construct the component.
+   * @param args Parameters to use to initialize the component.
    * @return A reference to the newly created component.
    */
-  template <typename Comp, typename ...Args>
+  template <typename Comp, typename... Args>
   Comp &assign(Args &&... args) {
     assert(!has<Comp>());
     auto component = std::make_unique<Component<Comp>>();
@@ -175,6 +176,40 @@ public:
   Comp &get() ENTT_NOEXCEPT {
     assert(has<Comp>());
     return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
+  }
+  
+  /**
+   * @brief Replaces the given component
+   *
+   * @warning
+   * An assertion will abort the execution at runtime in debug mode in case
+   * the prototype doesn't own the given component
+   *
+   * @tparam Comp Type of component to replace
+   * @tparam Args Types of arguments to use to construct the component
+   * @param args Parameters to use to initialize the component
+   * @return A refernce to the newly created component
+   */
+  template <typename Comp, typename... Args>
+  Comp &replace(Args &&... args) ENTT_NOEXCEPT {
+    return (get<Comp>() = Comp{std::forward<Args>(args)...});
+  }
+  
+  /**
+   * @brief Assigns of replaces the given component
+   *
+   * @tparam Comp Type of component to replace
+   * @tparam Args Types of arguments to use to construct the component
+   * @param args Parameters to use to initialize the component
+   * @return A refernce to the newly created component
+   */
+  template <typename Comp, typename... Args>
+  Comp &accommodate(Args &&... args) ENTT_NOEXCEPT {
+    if (has<Comp>()) {
+      return replace<Comp>(std::forward<Args>(args)...);
+    } else {
+      return assign<Comp>(std::forward<Args>(args)...);
+    }
   }
   
 private:

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -48,7 +48,7 @@ public:
     /**
      * @brief Checks if there exists at least one component assigned
      *
-     * @return True if at least one component is assigned
+     * @return True if no components are assigned
      */
     bool empty() const ENTT_NOEXCEPT {
         return std::all_of(comps.cbegin(), comps.cend(), [] (auto comp) {

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -51,7 +51,9 @@ public:
    * @return True if at least one component is assigned
    */
   bool empty() const ENTT_NOEXCEPT {
-    return comps.empty();
+    return std::all_of(comps.cbegin(), comps.cend(), [] (auto comp) {
+      return comp == nullptr;
+    });
   }
 
   /**

--- a/src/entt/entity/prototype.hpp
+++ b/src/entt/entity/prototype.hpp
@@ -1,0 +1,95 @@
+#ifndef ENTT_ENTITY_PROTOTYPE_HPP
+#define ENTT_ENTITY_PROTOTYPE_HPP
+
+#include "registry.hpp"
+
+template <typename Entity>
+class Prototype {
+public:
+  using entity_t = Entity;
+  using registry_t = entt::Registry<Entity>;
+  using family_t = entt::Family<struct PrototypeFamily>;
+
+private:
+  class ComponentBase {
+  public:
+    virtual ~ComponentBase() = default;
+    virtual void assign(registry_t &, entity_t) const = 0;
+  };
+  
+  template <typename Comp>
+  class Component : public ComponentBase {
+  public:
+    void assign(registry_t &registry, const entity_t entity) const override {
+      registry.template accommodate<Comp>(entity, comp);
+    }
+    
+    Comp comp;
+  };
+
+public:
+  Prototype() = default;
+  Prototype(Prototype &&) = default;
+  Prototype &operator=(Prototype &&) = default;
+
+  void operator()(registry_t &reg, const entity_t entity) const {
+    for (const std::unique_ptr<ComponentBase> &component : comps) {
+      if (component) {
+        component->assign(reg, entity);
+      }
+    }
+  }
+  entity_t operator()(registry_t &reg) const {
+    const entity_t entity = reg.create();
+    (*this)(reg, entity);
+    return entity;
+  }
+
+  template <typename Comp>
+  size_t type() const {
+    return family_t::template type<Comp>();
+  }
+
+  template <typename Comp, typename ...Args>
+  Comp &assign(Args &&... args) {
+    assert(!has<Comp>());
+    auto component = std::make_unique<Component<Comp>>();
+    component->comp = Comp {std::forward<Args>(args)...};
+    const size_t index = type<Comp>();
+    while (comps.size() <= index) {
+      comps.emplace_back();
+    }
+    Comp &comp = component->comp;
+    comps[index] = std::move(component);
+    return comp;
+  }
+  
+  template <typename Comp>
+  void remove() {
+    assert(has<Comp>());
+    comps[type<Comp>()] = nullptr;
+  }
+  
+  template <typename Comp>
+  bool has() const {
+    const size_t index = type<Comp>();
+    return index < comps.size() && comps[index] != nullptr;
+  }
+  
+  template <typename Comp>
+  const Comp &get() const {
+    assert(has<Comp>());
+    return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
+  }
+  
+  template <typename Comp>
+  Comp &get() {
+    assert(has<Comp>());
+    return static_cast<Component<Comp> *>(comps[type<Comp>()].get())->comp;
+  }
+  
+private:
+  std::vector<std::unique_ptr<ComponentBase>> comps;
+};
+
+#endif


### PR DESCRIPTION
I had this implementation lying around for a while so I thought I should clean it up and open a pull request. Issue #56 has a discussion about this feature. Here's an example:

```C++
#include <entt/entity/prototype.hpp>

struct Position {
  int x;
  int y;
};
struct Sprites {
  int id;
  int frames;
};
enum class TileType {
  WALL,
  ENEMY
};

// not every entity can be initialized with EXACTLY the same components
uint32_t make(const entt::DefaultPrototype &proto, entt::DefaultRegistry &reg, Position pos) {
  uint32_t entity = proto(reg);
  reg.assign<Position>(entity, pos);
  return entity;
}

int main() {
  // imagine we’re initialising prototypes from files
  entt::DefaultPrototype wall;
  wall.assign<Sprites>(0, 4);
  wall.assign<TileType>(TileType::WALL);
  
  entt::DefaultPrototype enemy;
  enemy.assign<Sprites>(4, 4);
  enemy.assign<TileType>(TileType::ENEMY);
  
  // put some walls and enemies around the place
  entt::DefaultRegistry reg;
  make(wall, reg, {0, 0});
  make(wall, reg, {3, 3});
  make(enemy, reg, {3, 0});
  make(enemy, reg, {0, 3});

  return 0;
}
```

In your games, you would probably initialize the prototypes from JSON files instead of hardcoded values. If you're not defining parts of your game in a file then a prototype is essentially a factory function.

Thoughts?