### PR TITLE
Adding parallel iteration to Raw, Persistent, and Single Component views.

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -7,4 +7,13 @@
 #endif
 
 
+//parallel algorithms only on C++ 17
+#if _HAS_CXX17
+
+#ifndef ENTT_HAS_PARALLEL_VIEW
+#define ENTT_HAS_PARALLEL_VIEW
+#endif
+
+#endif /* _HAS_CXX17 */
+
 #endif // ENTT_CONFIG_CONFIG_H

--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -64,12 +64,14 @@ class SparseSet<Entity> {
         using value_type = Entity;
         using pointer = const value_type *;
         using reference = value_type;
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
 
         Iterator(pointer direct, std::size_t pos)
             : direct{direct}, pos{pos}
         {}
-
+		Iterator()
+			: direct{ nullptr }, pos{ 0 }
+		{}
         Iterator & operator++() ENTT_NOEXCEPT {
             return --pos, *this;
         }
@@ -507,11 +509,14 @@ class SparseSet<Entity, Type>: public SparseSet<Entity> {
         using value_type = std::conditional_t<Const, const Type, Type>;
         using pointer = value_type *;
         using reference = value_type &;
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
 
         Iterator(pointer instances, std::size_t pos)
             : instances{instances}, pos{pos}
         {}
+		Iterator()
+			: instances{ nullptr }, pos{ 0 }
+		{}
 
         Iterator & operator++() ENTT_NOEXCEPT {
             return --pos, *this;

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -1232,6 +1232,20 @@ public:
         });
     }
 
+	template<typename Func>
+	void par_each(Func func) const {
+#ifdef ENTT_HAS_PARALLEL_VIEW
+		std::for_each(std::execution::par,pool.view_type::cbegin(), pool.view_type::cend(), [&func, raw = pool.cbegin()](const auto entity) mutable {
+			func(entity, *(raw++));
+		});
+#else
+		std::for_each(pool.view_type::cbegin(), pool.view_type::cend(), [&func, raw = pool.cbegin()](const auto entity) mutable {
+			func(entity, *(raw++));
+		});
+#endif
+		
+	}
+
     /**
      * @brief Iterates entities and components and applies the given function
      * object to them.
@@ -1252,7 +1266,13 @@ public:
         const_cast<const View *>(this)->each([&func](const entity_type entity, const Component &component) {
             func(entity, const_cast<Component &>(component));
         });
-    }
+    }	
+	template<typename Func>
+	inline void par_each(Func func) {
+		const_cast<const View *>(this)->par_each([&func](const entity_type entity, const Component &component) {
+			func(entity, const_cast<Component &>(component));
+		});
+	}
 
 private:
     pool_type &pool;

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -12,6 +12,9 @@
 #include "entt_traits.hpp"
 #include "sparse_set.hpp"
 
+#ifdef ENTT_HAS_PARALLEL_VIEW
+#include <execution>
+#endif
 
 namespace entt {
 
@@ -1483,6 +1486,15 @@ public:
         std::for_each(pool.cbegin(), pool.cend(), func);
     }
 
+	template<typename Func>
+	void par_each(Func func) const {
+#ifdef ENTT_HAS_PARALLEL_VIEW
+		std::for_each(std::execution::par,pool.cbegin(), pool.cend(), func);
+#else
+		std::for_each(pool.cbegin(), pool.cend(), func);
+#endif
+	}
+
     /**
      * @brief Iterates components and applies the given function object to them.
      *
@@ -1501,6 +1513,17 @@ public:
     void each(Func func) {
         std::for_each(pool.begin(), pool.end(), func);
     }
+
+
+	template<typename Func>
+	void par_each(Func func) {
+#ifdef ENTT_HAS_PARALLEL_VIEW
+		std::for_each(std::execution::par,pool.begin(), pool.end(), func);
+#else
+		std::for_each(pool.begin(), pool.end(), func);
+#endif
+	}
+
 
 private:
     pool_type &pool;

--- a/test/benchmark/benchmark.cpp
+++ b/test/benchmark/benchmark.cpp
@@ -110,6 +110,29 @@ TEST(Benchmark, IterateSingleComponent1M) {
         (void)accumulator;
     });
 }
+TEST(Benchmark, ParallelIterateSingleComponent1M) {
+	entt::DefaultRegistry registry;
+
+	std::cout << "Parallel iteration over 1000000 entities, one component" << std::endl;
+
+	for (std::uint64_t i = 0; i < 1000000L; i++) {
+		const auto entity = registry.create();
+		registry.assign<Position>(entity);
+	}
+
+	auto test = [&registry](auto func) {
+		Timer timer;
+		registry.view<Position>().par_each(func);
+		timer.elapsed();
+	};
+
+	test([](auto, const auto &) {});
+	test([](auto, auto &... comp) {
+		using accumulator_type = int[];
+		accumulator_type accumulator = { (comp.x = {}, 0)... };
+		(void)accumulator;
+	});
+}
 
 TEST(Benchmark, IterateSingleComponentRaw1M) {
     entt::DefaultRegistry registry;

--- a/test/benchmark/benchmark.cpp
+++ b/test/benchmark/benchmark.cpp
@@ -264,6 +264,31 @@ TEST(Benchmark, IterateTwoComponentsPersistent1M) {
         (void)accumulator;
     });
 }
+TEST(Benchmark, ParallelIterateTwoComponentsPersistent1M) {
+	entt::DefaultRegistry registry;
+	registry.prepare<Position, Velocity>();
+
+	std::cout << "Parallel Iteration over 1000000 entities, two components, persistent view" << std::endl;
+
+	for (std::uint64_t i = 0; i < 1000000L; i++) {
+		const auto entity = registry.create();
+		registry.assign<Position>(entity);
+		registry.assign<Velocity>(entity);
+	}
+
+	auto test = [&registry](auto func) {
+		Timer timer;
+		registry.view<Position, Velocity>(entt::persistent_t{}).par_each(func);
+		timer.elapsed();
+	};
+
+	test([](auto, const auto &...) {});
+	test([](auto, auto &... comp) {
+		using accumulator_type = int[];
+		accumulator_type accumulator = { (comp.x = {}, 0)... };
+		(void)accumulator;
+	});
+}
 
 TEST(Benchmark, IterateFiveComponents1M) {
     entt::DefaultRegistry registry;

--- a/test/benchmark/benchmark.cpp
+++ b/test/benchmark/benchmark.cpp
@@ -134,6 +134,29 @@ TEST(Benchmark, IterateSingleComponentRaw1M) {
         (void)accumulator;
     });
 }
+TEST(Benchmark, ParallelIterateSingleComponentRaw1M) {
+	entt::DefaultRegistry registry;
+
+	std::cout << "Parallel iteration over 1000000 entities, one component, raw view" << std::endl;
+
+	for (std::uint64_t i = 0; i < 1000000L; i++) {
+		const auto entity = registry.create();
+		registry.assign<Position>(entity);
+	}
+
+	auto test = [&registry](auto func) {
+		Timer timer;
+		registry.view<Position>(entt::raw_t{}).par_each(func);
+		timer.elapsed();
+	};
+
+	test([](const auto &) {});
+	test([](auto &... comp) {
+		using accumulator_type = int[];
+		accumulator_type accumulator = { (comp.x = {}, 0)... };
+		(void)accumulator;
+	});
+}
 
 TEST(Benchmark, IterateTwoComponents1M) {
     entt::DefaultRegistry registry;


### PR DESCRIPTION
Implemented the functions par_each() for raw, persistent, and single component views. The syntax is the same as each(), but renamed to par_each(). Due to the overhead of std::parallel algorithms they are a clear pessimization on the benchmark suite. They have to be used with care and only in the cases where each iteration is actually expensive, as the parallel execution carries some serious overhead.

They are highly dangerous to use, as creating or destroying entities will instantly crash the application. Accesing shared resources from that its also very dangerous. Editing only the components for the iteration works completely fine.

The reason behind par_each() instead of the talked about each(std::execution::par) is that std::execution::par doesnt exist on non C++17 compilers, so it would complicate the design i think.

Parallel iterators are only in the C++ 17 standard, so the implementation is fully `#ifdef`-d to have it work on other configurations without breaking compiling. If the compiler is not C++17, it will just do the normal non-parallel version.

The current parallel execution is just completely basic std::execution::par, from std::algorithm, wich is not an optimal implementation. A optimized implementation that actually separates the iterator properly will run much better than this basic version.

Important detail. The current version of google test suite does not compile well with visual studio , with our without C++17. I had to fix some things on the test suite to be able to run the benchmarks from visual studio 17.