### PR TITLE
fix warning on windows C4267

### DIFF
--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -1148,7 +1148,7 @@ public:
     void each(Func func) const {
         if(available) {
             for(auto pos = entities.size(); pos; --pos) {
-                const entity_type curr = pos - 1;
+                const entity_type curr = static_cast<entity_type>(pos - 1);
                 const auto entity = entities[curr];
                 const auto entt = entity & traits_type::entity_mask;
 


### PR DESCRIPTION
since size_t and unsigned int are different on windows we have to cast to entity_type.