### PR TITLE
exposing empty delegate check

### DIFF
--- a/src/entt/signal/delegate.hpp
+++ b/src/entt/signal/delegate.hpp
@@ -110,6 +110,17 @@ public:
         return stub.first == other.stub.first && stub.second == other.stub.second;
     }
 
+    /**
+     * @brief Checks whether the delegate actually stores a function.
+     *
+     * An empty delegate is a default constructed one.
+     *
+     * @return True if this delegate is empty, false otherwise.
+     */
+    bool empty() const ENTT_NOEXCEPT {
+        return !stub.first && stub.second == &fallback;
+    }
+
 private:
     stub_type stub;
 };


### PR DESCRIPTION
What do you think about it? This could be achieved using `delegate == {}` I guess, but maybe the `empty()` member function is more expressive...