### PR TITLE
allowing void() delegates

### DIFF
--- a/src/entt/signal/delegate.hpp
+++ b/src/entt/signal/delegate.hpp
@@ -37,7 +37,7 @@ class Delegate<Ret(Args...)> final {
     using proto_type = Ret(*)(void *, Args...);
     using stub_type = std::pair<void *, proto_type>;
 
-    static Ret fallback(void *, Args...) ENTT_NOEXCEPT { return {}; }
+    static Ret fallback(void *, Args...) ENTT_NOEXCEPT { return Ret(); }
 
     template<Ret(*Function)(Args...)>
     static Ret proto(void *, Args... args) {


### PR DESCRIPTION
I had compilers errors trying to connect a `void(bool)` function to a delegate; the compiler complained about not being able to return a value of type `void`. This should fix.