### PR TITLE
Port for VS 2015

### DIFF
--- a/src/entt/core/family.hpp
+++ b/src/entt/core/family.hpp
@@ -44,7 +44,7 @@ public:
 
 
 template<typename... Types>
-std::atomic<std::size_t> Family<Types...>::identifier{};
+std::atomic<std::size_t> Family<Types...>::identifier = {0}; // Workaround for VS2015: No list initialization
 
 
 }

--- a/src/entt/core/monostate.hpp
+++ b/src/entt/core/monostate.hpp
@@ -24,6 +24,9 @@ namespace entt {
  */
 template<HashedString::hash_type>
 struct Monostate {
+    /*! @brief Default constructor. Workaround for VS2015: fixes list initialization of this class. */
+    Monostate() {}
+
     /**
      * @brief Assigns a value of a specific type to a given key.
      * @tparam Type Type of the value to assign.
@@ -52,7 +55,7 @@ private:
 
 template<HashedString::hash_type ID>
 template<typename Type>
-std::atomic<Type> Monostate<ID>::value{};
+std::atomic<Type> Monostate<ID>::value = {}; // Workaround for VS2015: No list initialization
 
 
 }

--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -25,6 +25,21 @@
 
 namespace entt {
 
+namespace internal {
+
+template<typename... Types>
+using TupleCat = decltype(std::tuple_cat(std::declval<Types>()...));
+
+template<typename Type, typename... Types>
+using RemoveTypeFromTuple = TupleCat<
+    typename std::conditional<
+        std::is_same<Type, Types>::value,
+        std::tuple<>,
+        std::tuple<Types>
+    >::type...
+>;
+
+}
 
 /**
  * @brief Fast and reliable entity-component system.
@@ -74,32 +89,32 @@ class Registry {
         Tag tag;
     };
 
-    template<typename Comp, std::size_t Pivot, typename... Component, std::size_t... Indexes>
+    template<typename Comp, typename... Component, std::size_t... Indexes>
     void connect(std::index_sequence<Indexes...>) {
         auto &cpool = pools[component_family::type<Comp>()];
-        std::get<1>(cpool).sink().template connect<&Registry::creating<&handler_family::type<Component...>, std::tuple_element_t<(Indexes < Pivot ? Indexes : (Indexes+1)), std::tuple<Component...>>...>>();
+        std::get<1>(cpool).sink().template connect<&Registry::creating<&handler_family::type<Component...>, std::tuple_element_t<Indexes, internal::RemoveTypeFromTuple<Comp, Component...>>...>>();
         std::get<2>(cpool).sink().template connect<&Registry::destroying<Component...>>();
     }
 
-    template<typename... Component, std::size_t... Indexes>
-    void connect(std::index_sequence<Indexes...>) {
+    template<typename... Component>
+    void connect() {
         using accumulator_type = int[];
-        accumulator_type accumulator = { (assure<Component>(), connect<Component, Indexes, Component...>(std::make_index_sequence<sizeof...(Component)-1>{}), 0)... };
+        accumulator_type accumulator = { (assure<Component>(), connect<Component, Component...>(std::make_index_sequence<sizeof...(Component)-1>{}), 0)... };
         (void)accumulator;
     }
 
-    template<typename Comp, std::size_t Pivot, typename... Component, std::size_t... Indexes>
+    template<typename Comp, typename... Component, std::size_t... Indexes>
     void disconnect(std::index_sequence<Indexes...>) {
         auto &cpool = pools[component_family::type<Comp>()];
-        std::get<1>(cpool).sink().template disconnect<&Registry::creating<&handler_family::type<Component...>, std::tuple_element_t<(Indexes < Pivot ? Indexes : (Indexes+1)), std::tuple<Component...>>...>>();
+        std::get<1>(cpool).sink().template disconnect<&Registry::creating<&handler_family::type<Component...>, std::tuple_element_t<Indexes, internal::RemoveTypeFromTuple<Comp, Component...>>...>>();
         std::get<2>(cpool).sink().template disconnect<&Registry::destroying<Component...>>();
     }
 
-    template<typename... Component, std::size_t... Indexes>
-    void disconnect(std::index_sequence<Indexes...>) {
+    template<typename... Component>
+    void disconnect() {
         using accumulator_type = int[];
         // if a set exists, pools have already been created for it
-        accumulator_type accumulator = { (disconnect<Component, Indexes, Component...>(std::make_index_sequence<sizeof...(Component)-1>{}), 0)... };
+        accumulator_type accumulator = { (disconnect<Component, Component...>(std::make_index_sequence<sizeof...(Component)-1>{}), 0)... };
         (void)accumulator;
     }
 
@@ -1380,7 +1395,7 @@ public:
         }
 
         if(!handlers[htype]) {
-            connect<Component...>(std::make_index_sequence<sizeof...(Component)>{});
+            connect<Component...>();
             handlers[htype] = std::make_unique<SparseSet<entity_type>>();
             auto &handler = *handlers[htype];
 
@@ -1408,7 +1423,7 @@ public:
     template<typename... Component>
     void discard() {
         if(contains<Component...>()) {
-            disconnect<Component...>(std::make_index_sequence<sizeof...(Component)>{});
+            disconnect<Component...>();
             handlers[handler_family::type<Component...>()].reset();
         }
     }

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -486,13 +486,13 @@ class View final {
 
         using extent_type = typename view_type::size_type;
 
-        Iterator(unchecked_type unchecked, underlying_iterator_type begin, underlying_iterator_type end) ENTT_NOEXCEPT
+        Iterator(unchecked_type unchecked, underlying_iterator_type begin_iter, underlying_iterator_type end_iter) ENTT_NOEXCEPT
             : unchecked{unchecked},
-              begin{begin},
-              end{end},
+              begin_iter{begin_iter},
+              end_iter{end_iter},
               extent{min(std::make_index_sequence<unchecked.size()>{})}
         {
-            if(begin != end && !valid()) {
+            if(begin_iter != end_iter && !valid()) {
                 ++(*this);
             }
         }
@@ -503,7 +503,7 @@ class View final {
         }
 
         bool valid() const ENTT_NOEXCEPT {
-            const auto entity = *begin;
+            const auto entity = *begin_iter;
             const auto sz = size_type(entity & traits_type::entity_mask);
 
             return sz < extent && std::all_of(unchecked.cbegin(), unchecked.cend(), [entity](const view_type *view) {
@@ -524,7 +524,7 @@ class View final {
         Iterator & operator=(const Iterator &) ENTT_NOEXCEPT = default;
 
         Iterator & operator++() ENTT_NOEXCEPT {
-            return (++begin != end && !valid()) ? ++(*this) : *this;
+            return (++begin_iter != end_iter && !valid()) ? ++(*this) : *this;
         }
 
         Iterator operator++(int) ENTT_NOEXCEPT {
@@ -533,7 +533,7 @@ class View final {
         }
 
         bool operator==(const Iterator &other) const ENTT_NOEXCEPT {
-            return other.begin == begin;
+            return other.begin_iter == begin_iter;
         }
 
         inline bool operator!=(const Iterator &other) const ENTT_NOEXCEPT {
@@ -541,7 +541,7 @@ class View final {
         }
 
         pointer operator->() const ENTT_NOEXCEPT {
-            return begin.operator->();
+            return begin_iter.operator->();
         }
 
         inline reference operator*() const ENTT_NOEXCEPT {
@@ -550,8 +550,8 @@ class View final {
 
     private:
         unchecked_type unchecked;
-        underlying_iterator_type begin;
-        underlying_iterator_type end;
+        underlying_iterator_type begin_iter;
+        underlying_iterator_type end_iter;
         extent_type extent;
     };
 
@@ -1600,20 +1600,20 @@ class RuntimeView {
     class Iterator {
         friend class RuntimeView<Entity>;
 
-        Iterator(underlying_iterator_type begin, underlying_iterator_type end, const view_type * const *first, const view_type * const *last, extent_type extent) ENTT_NOEXCEPT
-            : begin{begin},
-              end{end},
+        Iterator(underlying_iterator_type begin_iter, underlying_iterator_type end_iter, const view_type * const *first, const view_type * const *last, extent_type extent) ENTT_NOEXCEPT
+            : begin_iter{begin_iter},
+              end_iter{end_iter},
               first{first},
               last{last},
               extent{extent}
         {
-            if(begin != end && !valid()) {
+            if(begin_iter != end_iter && !valid()) {
                 ++(*this);
             }
         }
 
         bool valid() const ENTT_NOEXCEPT {
-            const auto entity = *begin;
+            const auto entity = *begin_iter;
             const auto sz = size_type(entity & traits_type::entity_mask);
 
             return sz < extent && std::all_of(first, last, [entity](const auto *view) {
@@ -1634,7 +1634,7 @@ class RuntimeView {
         Iterator & operator=(const Iterator &) ENTT_NOEXCEPT = default;
 
         Iterator & operator++() ENTT_NOEXCEPT {
-            return (++begin != end && !valid()) ? ++(*this) : *this;
+            return (++begin_iter != end_iter && !valid()) ? ++(*this) : *this;
         }
 
         Iterator operator++(int) ENTT_NOEXCEPT {
@@ -1643,7 +1643,7 @@ class RuntimeView {
         }
 
         bool operator==(const Iterator &other) const ENTT_NOEXCEPT {
-            return other.begin == begin;
+            return other.begin_iter == begin_iter;
         }
 
         inline bool operator!=(const Iterator &other) const ENTT_NOEXCEPT {
@@ -1651,7 +1651,7 @@ class RuntimeView {
         }
 
         pointer operator->() const ENTT_NOEXCEPT {
-            return begin.operator->();
+            return begin_iter.operator->();
         }
 
         inline reference operator*() const ENTT_NOEXCEPT {
@@ -1659,8 +1659,8 @@ class RuntimeView {
         }
 
     private:
-        underlying_iterator_type begin;
-        underlying_iterator_type end;
+        underlying_iterator_type begin_iter;
+        underlying_iterator_type end_iter;
         const view_type * const *first;
         const view_type * const *last;
         extent_type extent;

--- a/src/entt/locator/locator.hpp
+++ b/src/entt/locator/locator.hpp
@@ -107,7 +107,7 @@ private:
 
 
 template<typename Service>
-std::shared_ptr<Service> ServiceLocator<Service>::service{};
+std::shared_ptr<Service> ServiceLocator<Service>::service; // Workaround for VS2015: No list initialization.
 
 
 }

--- a/src/entt/process/scheduler.hpp
+++ b/src/entt/process/scheduler.hpp
@@ -109,7 +109,9 @@ class Scheduler final {
     static auto then(ProcessHandler *handler, Args &&... args) {
         if(handler) {
             auto proc = typename ProcessHandler::instance_type{new Proc{std::forward<Args>(args)...}, &Scheduler::deleter<Proc>};
-            handler->next.reset(new ProcessHandler{std::move(proc), &Scheduler::update<Proc>, &Scheduler::abort<Proc>, nullptr});
+            auto updateProc = static_cast<bool(*)(ProcessHandler&, const Delta, void*)>(&Scheduler::update<Proc>);
+            auto abortProc = static_cast<void(*)(ProcessHandler&, const bool)>(&Scheduler::abort<Proc>);
+            handler->next.reset(new ProcessHandler{std::move(proc), updateProc, abortProc, nullptr});
             handler = handler->next.get();
         }
 


### PR DESCRIPTION
- Removed list initialization of static members;

- Replaced Identifier::get constexpr function with helper struct internal::IndexOf;

- Added default ctor for Monostate to let it be {}-initialized.

- Replace pivot trick in Registry::connect/disconnect with RemoveTypeFromTuple helper struct.

- Rename begin/end members in View and RealtimeView iterators in order to fix GTest trying to interpret iterators as containers.

- Add casts to Scheduler::then to fix function overload ambiguity.
