### PR TITLE
fixed invalid conversion from lambda to noexcept function ptr

### DIFF
--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -615,7 +615,7 @@ MetaTypeNode * MetaInfo::resolve() ENTT_NOEXCEPT {
             {},
             MetaInfo::type<>,
             nullptr,
-            []() -> MetaType * {
+            []() ENTT_NOEXCEPT -> MetaType * {
                 return nullptr;
             }
         };


### PR DESCRIPTION
Was not able to call the `resolve<T>()` function under g++ 8.2.0 cause of this missing noexcept.