### PR TITLE
Fix find_package(EnTT) when EnTT is installed using vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,6 @@ configure_package_config_file(
     ${CUSTOM_INSTALL_CONFIGDIR}/EnTTConfig.cmake
     INSTALL_DESTINATION ${CUSTOM_INSTALL_CONFIGDIR}
     PATH_VARS CMAKE_INSTALL_INCLUDEDIR
-    NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
 write_basic_package_version_file(


### PR DESCRIPTION
This commit fixes a bug where find_package(EnTT) fails when EnTT is
installed using vcpkg.

The bug occurs because EnTTConfig.cmake.in calls
check_required_components(), yet the call to
configure_package_config_file() in CMakeLists.txt that generates
EnTTConfig.cmake is passed NO_CHECK_REQUIRED_COMPONENTS_MACRO. This
causes CMake to error when it tries to parse the output EnTTConfig.cmake
file if that file is generated from EnTTConfig.cmake.in e.g. when
installing EnTT using vcpkg.