### PR TITLE
Add basic Conan support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.user
+conan/test_package/build
+
+# IDEs
+.idea

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.7.2)
+project(test_package)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/conan/test_package/test_package.cpp
+++ b/conan/test_package/test_package.cpp
@@ -1,0 +1,55 @@
+#include <entt/entt.hpp>
+#include <cstdint>
+#include <cstdlib>
+
+struct position {
+    float x;
+    float y;
+};
+
+struct velocity {
+    float dx;
+    float dy;
+};
+
+void update(entt::registry<> &registry) {
+    auto view = registry.view<position, velocity>();
+
+    for(auto entity: view) {
+        // gets only the components that are going to be used ...
+
+        auto &vel = view.get<velocity>(entity);
+
+        vel.dx = 0.;
+        vel.dy = 0.;
+
+        // ...
+    }
+}
+
+void update(std::uint64_t dt, entt::registry<> &registry) {
+    registry.view<position, velocity>().each([dt](const auto, auto &pos, auto &vel) {
+        // gets all the components of the view at once ...
+
+        pos.x += vel.dx * dt;
+        pos.y += vel.dy * dt;
+
+        // ...
+    });
+}
+
+int main() {
+    entt::registry<> registry;
+    std::uint64_t dt = 16;
+
+    for(auto i = 0; i < 10; ++i) {
+        auto entity = registry.create();
+        registry.assign<position>(entity, i * 1.f, i * 1.f);
+        if(i % 2 == 0) { registry.assign<velocity>(entity, i * .1f, i * .1f); }
+    }
+
+    update(dt, registry);
+    update(registry);
+
+    return EXIT_SUCCESS;
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from conans import ConanFile
+
+
+class EnttConan(ConanFile):
+    name = "entt"
+    description = "Gaming meets modern C++ - a fast and reliable entity-component system (ECS) and much more "
+    topics = ("conan," "entt", "gaming", "entity", "ecs")
+    url = "https://github.com/skypjack/entt"
+    homepage = url
+    author = "Michele Caini <michele.caini@gmail.com>"
+    license = "MIT"
+    exports = ["LICENSE"]
+    exports_sources = ["src/*"]
+    no_copy_source = True
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy(pattern="*", dst="include", src="src", keep_path=True)
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
This adds basic Conan support.

Packages can be build with

`conan create . entt/<version-number>@skypjack/stable`

Packages can be test with

`conan create . entt/<version-number>@skypjack/stable -tf conan/test_package`

(the parameter tf stands for test_package)

____

I will create a separate pull request for adding CI building/testing/publishing later.


____

Cross-referencing: https://github.com/conan-io/wishlist/issues/166

