### PR TITLE
UB/Crash in entt::insertion_sort

### DIFF
--- a/src/entt/core/algorithm.hpp
+++ b/src/entt/core/algorithm.hpp
@@ -54,16 +54,16 @@ struct insertion_sort final {
      */
     template<typename It, typename Compare = std::less<>>
     void operator()(It first, It last, Compare compare = Compare{}) const {
-        if (first != last)
+        if(first != last)
         {
             auto it = first + 1;
 
-            while (it != last) {
+            while(it != last) {
                 auto value = *it;
                 auto pre = it;
 
-                while (pre != first && compare(value, *(pre - 1))) {
-                    *pre = *(pre - 1);
+                while(pre != first && compare(value, *(pre-1))) {
+                    *pre = *(pre-1);
                     --pre;
                 }
 

--- a/src/entt/core/algorithm.hpp
+++ b/src/entt/core/algorithm.hpp
@@ -54,19 +54,22 @@ struct insertion_sort final {
      */
     template<typename It, typename Compare = std::less<>>
     void operator()(It first, It last, Compare compare = Compare{}) const {
-        auto it = first + 1;
+        if (first != last)
+        {
+            auto it = first + 1;
 
-        while(it != last) {
-            auto value = *it;
-            auto pre = it;
+            while (it != last) {
+                auto value = *it;
+                auto pre = it;
 
-            while(pre != first && compare(value, *(pre-1))) {
-                *pre = *(pre-1);
-                --pre;
+                while (pre != first && compare(value, *(pre - 1))) {
+                    *pre = *(pre - 1);
+                    --pre;
+                }
+
+                *pre = value;
+                ++it;
             }
-
-            *pre = value;
-            ++it;
         }
     }
 };


### PR DESCRIPTION
Currently, `insertion_sort::operator()` in core/algorithm.hpp is implemented like this:

    template<typename It, typename Compare = std::less<>>
    void operator()(It first, It last, Compare compare = Compare{}) const {
        auto it = first + 1;

        while(it != last) {
            auto value = *it;
            auto pre = it;

            while(pre != first && compare(value, *(pre-1))) {
                *pre = *(pre-1);
                --pre;
            }

            *pre = value;
            ++it;
        }
    }

Notice that `first` is incremented at the very beginning. This is undefined behaviour if `first` is the past-the-end-iterator. Therefore, the following example crashes with VC++ 14.16:

    #include <entt/core/algorithm.hpp>
    #include <vector>

    int main()
    {
        std::vector<int> v{};
        entt::insertion_sort sort{};

        sort(v.begin(), v.end())
    }

This can easily be fixed by comparing `first` and `last` at the beginning of the `operator()`-function (if `first` is past-the-end, `last` has to be past-the-end too).