### PR TITLE
Fix compile error when compiling example with GCC8

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ struct velocity {
     float dy;
 };
 
-void update(entt::registry &registry) {
+void update(entt::registry<uint32_t> &registry) {
     auto view = registry.view<position, velocity>();
 
     for(auto entity: view) {
@@ -114,7 +114,7 @@ void update(entt::registry &registry) {
     }
 }
 
-void update(std::uint64_t dt, entt::registry &registry) {
+void update(std::uint64_t dt, entt::registry<uint32_t> &registry) {
     registry.view<position, velocity>().each([dt](const auto, auto &pos, auto &vel) {
         // gets all the components of the view at once ...
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ struct velocity {
     float dy;
 };
 
-void update(entt::registry<uint32_t> &registry) {
+void update(entt::registry<> &registry) {
     auto view = registry.view<position, velocity>();
 
     for(auto entity: view) {
@@ -114,7 +114,7 @@ void update(entt::registry<uint32_t> &registry) {
     }
 }
 
-void update(std::uint64_t dt, entt::registry<uint32_t> &registry) {
+void update(std::uint64_t dt, entt::registry<> &registry) {
     registry.view<position, velocity>().each([dt](const auto, auto &pos, auto &vel) {
         // gets all the components of the view at once ...
 


### PR DESCRIPTION
GCC8 does not auto-deduce the template parameter for entt::registry, so it has to be provided explicitly.