### PR TITLE
Fix sparse_set invalid state when component constructor throws

### DIFF
--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -164,7 +164,7 @@ class sparse_set<Entity> {
         }
 
     private:
-        direct_type *direct;st
+        direct_type *direct;
         index_type index;
     };
 

--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -914,9 +914,9 @@ public:
      */
     template<typename... Args>
     object_type & construct([[maybe_unused]] const entity_type entity, [[maybe_unused]] Args &&... args) {
-        underlying_type::construct(entity);
 
         if constexpr(std::is_empty_v<object_type>) {
+            underlying_type::construct(entity);
             return instances;
         } else {
             if constexpr(std::is_aggregate_v<object_type>) {
@@ -924,7 +924,8 @@ public:
             } else {
                 instances.emplace_back(std::forward<Args>(args)...);
             }
-
+            // construct entity after component in case component constructor throws
+            underlying_type::construct(entity);
             return instances.back();
         }
     }

--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -164,7 +164,7 @@ class sparse_set<Entity> {
         }
 
     private:
-        direct_type *direct;
+        direct_type *direct;st
         index_type index;
     };
 
@@ -914,7 +914,6 @@ public:
      */
     template<typename... Args>
     object_type & construct([[maybe_unused]] const entity_type entity, [[maybe_unused]] Args &&... args) {
-
         if constexpr(std::is_empty_v<object_type>) {
             underlying_type::construct(entity);
             return instances;
@@ -924,7 +923,8 @@ public:
             } else {
                 instances.emplace_back(std::forward<Args>(args)...);
             }
-            // construct entity after component in case component constructor throws
+
+            // entity goes after component in case constructor throws
             underlying_type::construct(entity);
             return instances.back();
         }

--- a/test/entt/entity/sparse_set.cpp
+++ b/test/entt/entity/sparse_set.cpp
@@ -1056,23 +1056,22 @@ TEST(SparseSetWithType, CloneMoveOnlyComponent) {
     ASSERT_EQ(set.clone(), nullptr);
 }
 
-TEST(SparseSetWithType, ConstructorExceptionDoesNotAddToSet)
-{
-    class ThrowingComponent {
-    public:
-        class ConstructorException : public std::exception {};
-        ThrowingComponent() { throw ConstructorException{}; }
+TEST(SparseSetWithType, ConstructorExceptionDoesNotAddToSet) {
+    struct throwing_component {
+        struct constructor_exception: std::exception {};
+        
+        throwing_component() { throw constructor_exception{}; }
 
-        // necessary to avoid the short-circuit construct() logic for 0-size objects
+        // necessary to avoid the short-circuit construct() logic for empty objects
         int data;
     };
 
-    entt::sparse_set<std::uint64_t, ThrowingComponent> set;
+    entt::sparse_set<std::uint64_t, throwing_component> set;
 
     try {
         set.construct(0);
-        FAIL() << "Expected ConstructorException to be thrown";
-    } catch (const ThrowingComponent::ConstructorException& e) {
-        ASSERT_FALSE(set.has(0));
+        FAIL() << "Expected constructor_exception to be thrown";
+    } catch (const throwing_component::constructor_exception &) {
+        ASSERT_TRUE(set.empty());
     }
 }

--- a/test/entt/entity/sparse_set.cpp
+++ b/test/entt/entity/sparse_set.cpp
@@ -1,7 +1,7 @@
 #include <memory>
+#include <exception>
 #include <algorithm>
 #include <unordered_set>
-#include <exception>
 #include <gtest/gtest.h>
 #include <entt/entity/sparse_set.hpp>
 


### PR DESCRIPTION
# Preamble

First off, thank you for creating such an amazing piece of free software! 

I started creating a [similar library](https://github.com/cstegel/glomerate) to this when I surveyed the landscape of open source entity component systems a couple years ago and did not like what I found. I only needed it for one project at the time and then stopped working on it shortly after the project was done. When I searched for open source ECS recently I stumbled across `entt` and I am very impressed!

Any ways, on to the actual bug and fix...

# Bug Description

Previously, a component's constructor that throws would cause the sparse
set to think that the entity still exists in the set. This is because the underlying
sparse set that stores the entities will have its entry added before the component 
is added to the component set.

# Examples of Unintended Behaviour

This could cause a number of invalid memory access problems such as the following:

1) Exception triggers destructor of enclosing object that then tries to remove
   the component that was just added. SparseSet<entity_t, Component>::has() will
   return true for the entity but when destroy() is called "instances" will be empty
   so instances.back() will be invalid.

2) If the exception is handled then calling get(entity) for the same entity
   identifier that initially threw the exception will give a position for that
   entity even though it was not added. This can cause an invalid memory access
   or accessing the data of a different stored component.