### PR TITLE
rough proof of concept of swapping by using type member aliasing 

### DIFF
--- a/test/entt/entity/sparse_set.cpp
+++ b/test/entt/entity/sparse_set.cpp
@@ -10,6 +10,28 @@
 
 struct empty_type {};
 
+
+struct A { int a; };
+struct B : A {
+    using instance_type = A;
+};
+
+TEST(SparseSetSwapping, Basic) {
+
+    static_assert(std::is_class<B::instance_type>::value);
+    static_assert(has_type_instance_type<B>::value);
+    static_assert(!has_type_instance_type<A>::value);
+
+    static_assert(std::is_same<get_type_instance_type<B>::type, A>::value);
+    static_assert(std::is_same<std::decay<B>::type, B>::value);
+
+    entt::sparse_set<std::uint64_t, A> aset;
+    entt::sparse_set<std::uint64_t, B> bset;
+
+    aset.swap_instances(bset);
+
+}
+
 TEST(SparseSetNoType, Functionalities) {
     entt::sparse_set<std::uint64_t> set;
 


### PR DESCRIPTION
this probably leaves options for swapping but also could enable components declaring their own container type. theoretically should work fine if the strong types are inheriting the container type. it's hacked right now so don't actually accept it, but you can use it as POC