### PR TITLE
A strong type alias wrapper

### DIFF
--- a/src/entt/core/alias.hpp
+++ b/src/entt/core/alias.hpp
@@ -1,0 +1,84 @@
+#ifndef ENTT_CORE_ALIAS_HPP
+#define ENTT_CORE_ALIAS_HPP
+
+#include <utility>
+#include <type_traits>
+
+namespace entt {
+
+template <typename Value, typename Tag>
+class alias {
+public:
+    using value_type = Value;
+    using tag_type = Tag;
+
+    template <typename... Args>
+    constexpr explicit alias(Args &&... args) noexcept(noexcept(Value{std::forward<Args>(args)...}))
+        : v{std::forward<Args>(args)...} {}
+
+    template <typename OtherTag>
+    constexpr explicit alias(const alias<Value, OtherTag> &other) noexcept(noexcept(Value{*other}))
+        : v{*other} {}
+    template <typename OtherTag>
+    constexpr explicit alias(alias<Value, OtherTag> &&other) noexcept(noexcept(Value{std::move(*other)}))
+        : v{std::move(*other)} {}
+
+    constexpr Value &operator*() & noexcept {
+        return v;
+    }
+    constexpr const Value &operator*() const & noexcept {
+        return v;
+    }
+    constexpr Value &&operator*() && noexcept {
+        return v;
+    }
+    constexpr const Value &&operator*() const && noexcept {
+        return v;
+    }
+
+    constexpr Value *operator->() noexcept {
+        return &v;
+    }
+    constexpr const Value *operator->() const noexcept {
+        return &v;
+    }
+
+    constexpr bool operator==(const alias &other) const noexcept(noexcept(v == other.v)) {
+        return v == other.v;
+    }
+    constexpr bool operator!=(const alias &other) const noexcept(noexcept(v != other.v)) {
+        return v != other.v;
+    }
+    constexpr bool operator<(const alias &other) const noexcept(noexcept(v < other.v)) {
+        return v < other.v;
+    }
+    constexpr bool operator>(const alias &other) const noexcept(noexcept(v > other.v)) {
+        return v > other.v;
+    }
+    constexpr bool operator<=(const alias &other) const noexcept(noexcept(v <= other.v)) {
+        return v <= other.v;
+    }
+    constexpr bool operator>=(const alias &other) const noexcept(noexcept(v >= other.v)) {
+        return v >= other.v;
+    }
+
+private:
+    Value v;
+};
+
+template <typename Value, typename Tag>
+constexpr void swap(alias<Value, Tag> &lhs, alias<Value, Tag> &rhs) noexcept(noexcept(std::is_nothrow_swappable_v<Value>)) {
+    using std::swap;
+    swap(*lhs, *rhs);
+}
+
+}
+
+template <typename Value, typename Tag>
+struct std::hash<entt::alias<Value, Tag>> {
+    constexpr size_t operator()(const entt::alias<Value, Tag> &alias) const noexcept(noexcept(std::hash<Value>{}(*alias))) {
+        return std::hash<Value>{}(*alias);
+    }
+};
+
+#endif // ENTT_CORE_ALIAS_HPP

--- a/src/entt/core/alias.hpp
+++ b/src/entt/core/alias.hpp
@@ -12,7 +12,7 @@ public:
     using value_type = Value;
     using tag_type = Tag;
 
-    template <typename... Args>
+    template <typename... Args, typename = decltype(Value{std::declval<Args>()...})>
     constexpr explicit alias(Args &&... args) noexcept(noexcept(Value{std::forward<Args>(args)...}))
         : v{std::forward<Args>(args)...} {}
 
@@ -22,6 +22,16 @@ public:
     template <typename OtherTag>
     constexpr explicit alias(alias<Value, OtherTag> &&other) noexcept(noexcept(Value{std::move(*other)}))
         : v{std::move(*other)} {}
+
+    template <typename OtherValue, typename = decltype(Value{std::declval<OtherValue>()})>
+    constexpr alias(OtherValue &&other) noexcept(noexcept(Value{std::forward<OtherValue>(other)}))
+        : v{std::forward<OtherValue>(other)} {}
+
+    template <typename OtherValue, typename = decltype(std::declval<Value &>() = std::declval<OtherValue>())>
+    constexpr alias &operator=(OtherValue &&other) noexcept(noexcept(v = std::forward<OtherValue>(other))) {
+        v = std::forward<OtherValue>(other);
+        return *this;
+    }
 
     constexpr Value &operator*() & noexcept {
         return v;


### PR DESCRIPTION
I thought about the problem that @iderik was having on Gitter. This might be a solution. It's a strong type alias wrapper. It acts like a `std::optional` that always contains a value. Here's a usage example:

```C++
struct vec3 {
  int x, y, z;
};

vec3 operator+(const vec3 &lhs, const vec3 &rhs) {
  return {lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z};
}

using position = entt::alias<vec3, struct position_tag>;
using velocity = entt::alias<vec3, struct velocity_tag>;
using rotation = entt::alias<vec3, struct rotation_tag>;

int main() {
  entt::registry reg;
  entt::entity e = reg.create();
  reg.assign<position>(e, 1, 2, 3); // works
  reg.assign<position>(e, vec3{1, 2, 3}); // also works
  
  // aggregate initialization works
  velocity vel{4, 5, 6};
  // access with with -> operator
  vel->x += 3;

  // must use static_cast here
  // this is good because you don't want to accidentally assign velocity to rotation!
  rotation rot = static_cast<rotation>(vel);
  
  // this is allowed though
  rotation rot1 = *vel;
  // but this isn't
  // rotation rot2 = vel;

  // you have to dereference to access overloaded operators
  // you don't have to do a cast here
  rot = *rot + *rot;
  // you don't have to do a cast here either
  rotation rot1 = *rot + *rot;
  // should we allow the above implicit conversions?
  // I think so

  // move-only types work too
  using ptr = entt::alias<std::unique_ptr<int>, struct ptr_tag>;
  
  ptr p;
  p = std::make_unique<int>(4);
  ptr q = std::make_unique<int>(8);
  p = std::move(q);
  // obviously not allowed
  // p = q;
}
```

The usage example speaks for itself. Looking at the code, I can't help but think I've just overengineered a solution to a problem that doesn't really exist. You could just do this:

```C++
struct position { vec3 p; };
struct velocity { vec3 v; };
struct rotation { vec3 r; };
```

This wrapper removes a few characters here and there and tries to be as transparent as possible. I don't know why I feel so inclined to use `constexpr` and `noexcept` so excessively when writing generic code. I never use `noexcept` and rarely use `constexpr` when writing "real" code! I haven't used `ENTT_NOEXCEPT` because it doesn't allow parametized `noexcept`. Should we add a `ENTT_NOEXCEPT_ARG` macro or remove the `noexcept` specifications?

This is still a POC at this point. I'm not sure if this is a good idea.