### PR TITLE
Type concat

### DIFF
--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -13,10 +13,20 @@ namespace entt {
 template<typename... Type>
 struct type_list {};
 
+/* Recursive static method for confirming all types are unique */
+template <typename...>
+inline constexpr auto is_unique = std::true_type{};
+
+template <typename T, typename... Rest>
+inline constexpr auto is_unique<T, Rest...> = std::bool_constant<
+    (!std::is_same_v<T, Rest> && ...) && is_unique<Rest...>
+>{};
+
 /*! @brief A class to use to concat type lists. This is useful among other
 things for composing group inclusion and exlusion lists.*/
 template<typename... T1, typename... T2, template <typename...> class T>
 auto concat_types(T<T1...>, T<T2...>) {
+    static_assert(is_unique<T1..., T2...>);
     return T<T1..., T2...>{};
 }
 

--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -13,6 +13,12 @@ namespace entt {
 template<typename... Type>
 struct type_list {};
 
+/*! @brief A class to use to concat type lists. This is useful among other
+things for composing group inclusion and exlusion lists.*/
+template<typename... T1, typename... T2, template <typename...> class T>
+auto concat_types(T<T1...>, T<T2...>) {
+    return T<T1..., T2...>{};
+}
 
 /*! @brief Traits class used mainly to push things across boundaries. */
 template<typename>

--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -26,7 +26,9 @@ inline constexpr auto is_unique<T, Rest...> = std::bool_constant<
 things for composing group inclusion and exlusion lists.*/
 template<typename... T1, typename... T2, template <typename...> class T>
 auto concat_types(T<T1...>, T<T2...>) {
-    static_assert(is_unique<T1..., T2...>);
+    // i can't think of an instance where we'd want non-unique type list... so
+    // let's assume unique enforcement...
+    static_assert(is_unique<T1..., T2...>, "type lists need to be unique within entt api");
     return T<T1..., T2...>{};
 }
 

--- a/test/entt/entity/group.cpp
+++ b/test/entt/entity/group.cpp
@@ -109,10 +109,12 @@ TEST(NonOwningGroup, ConcatExcludeLists) {
     const auto string_types = entt::exclude<char>;
     const auto numeric_types = entt::exclude<int, float>;
     const auto exclude_all = entt::concat_types(string_types, numeric_types);
+    // invalid list concat
+    // this code below shouldn't compile...
+    // const auto invalid = entt::concat_types(numeric_types, numeric_types);
 
     entt::registry registry;
-    // groups are smart enough to differentiate that is exclusionary group
-    // list.
+    // groups are smart enough to differentiate that is exclusionary group list.
     auto all_group = registry.group<std::string>(exclude_all);
 
 

--- a/test/entt/entity/group.cpp
+++ b/test/entt/entity/group.cpp
@@ -82,6 +82,51 @@ TEST(NonOwningGroup, Functionalities) {
     ASSERT_FALSE(group.capacity());
 }
 
+
+TEST(NonOwningGroup, ConcatGetLists) {
+    // validate that get type lists can be concatenated together to form a group.
+    const auto string_types = entt::get<char, std::string>;
+    const auto numeric_types = entt::get<int, float>;
+    const auto all_types = entt::concat_types(string_types, numeric_types);
+
+    entt::registry registry;
+    auto string_group = registry.group<>(string_types);
+    auto numeric_group = registry.group<>(numeric_types);
+    auto all_group = registry.group<>(all_types);
+
+
+    const auto e1 = registry.create();
+    registry.assign<int>(e1);
+    registry.assign<char>(e1);
+    registry.assign<std::string>(e1);
+    registry.assign<float>(e1);
+    ASSERT_EQ(string_group.size(), all_group.size());
+    ASSERT_EQ(numeric_group.size(), all_group.size());
+}
+
+TEST(NonOwningGroup, ConcatExcludeLists) {
+    // validate that exclusionary type lists can be concatenated together to form a group.
+    const auto string_types = entt::exclude<char>;
+    const auto numeric_types = entt::exclude<int, float>;
+    const auto exclude_all = entt::concat_types(string_types, numeric_types);
+
+    entt::registry registry;
+    // groups are smart enough to differentiate that is exclusionary group
+    // list.
+    auto all_group = registry.group<std::string>(exclude_all);
+
+
+    const auto e1 = registry.create();
+    registry.assign<int>(e1);
+    registry.assign<char>(e1);
+    registry.assign<std::string>(e1);
+    registry.assign<float>(e1);
+    const auto e2 = registry.create();
+    registry.assign<std::string>(e2);
+    ASSERT_EQ(all_group.size(), 1);
+}
+
+
 TEST(NonOwningGroup, ElementAccess) {
     entt::registry registry;
     auto group = registry.group<>(entt::get<int, char>);


### PR DESCRIPTION
Is it actually useful to concat type lists? ... maybe yes if the group lists are big enough and the composition makes sense... if anything it could expose some more useful api opportunities. I'm at the c++ learning stage where complicated magical type folding logic *clearly* belongs in an api.