### PR TITLE
string view hashing

### DIFF
--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -63,9 +63,24 @@ class hashed_string {
         const char *str;
     };
 
+    struct view_wrapper {
+        // explicit constructor on purpose
+        constexpr view_wrapper(const std::string_view curr) ENTT_NOEXCEPT: str{curr} {}
+        // constexpr const_wrapper(std::string_view curr) ENTT_NOEXCEPT: str{curr} {}
+        const std::string_view str;
+    };
+
     // Fowler–Noll–Vo hash function v. 1a - the good
     inline static constexpr ENTT_ID_TYPE helper(ENTT_ID_TYPE partial, const char *curr) ENTT_NOEXCEPT {
         return curr[0] == 0 ? partial : helper((partial^curr[0])*traits_type::prime, curr+1);
+    }
+
+    // string_view implemenation of hash
+    inline static constexpr ENTT_ID_TYPE helper(ENTT_ID_TYPE partial, std::string_view s) ENTT_NOEXCEPT {
+        for (uint i = 0; i < s.size(); ++i) {
+            partial = (partial^s[i])*traits_type::prime;
+        }
+        return partial;
     }
 
 public:
@@ -98,6 +113,10 @@ public:
      * @return The numeric representation of the string.
      */
     inline static hash_type to_value(const_wrapper wrapper) ENTT_NOEXCEPT {
+        return helper(traits_type::offset, wrapper.str);
+    }
+
+    inline static hash_type to_value(view_wrapper wrapper) ENTT_NOEXCEPT {
         return helper(traits_type::offset, wrapper.str);
     }
 
@@ -173,7 +192,6 @@ private:
     hash_type hash;
     const char *str;
 };
-
 
 /**
  * @brief Compares two hashed strings.

--- a/test/entt/core/hashed_string.cpp
+++ b/test/entt/core/hashed_string.cpp
@@ -28,6 +28,14 @@ TEST(HashedString, Functionalities) {
     ASSERT_NE(bar_hs, "foo"_hs);
 }
 
+TEST(HashedString, StringView) {
+
+    const char *bar = "bar";
+    auto bar_hs = entt::hashed_string{bar};
+    std::string_view sview = bar;
+    ASSERT_EQ(bar_hs.value(), entt::hashed_string::to_value(sview));
+}
+
 TEST(HashedString, Empty) {
     using hash_type = entt::hashed_string::hash_type;
 


### PR DESCRIPTION
I found myself needing to compare a hashed_string value against a string_view in an api call, so I thought it may be useful to have explicit handler for string views in entt:hashed_string.


```
    explicit constexpr hashed_string(const_wrapper wrapper) ENTT_NOEXCEPT
        : hash{helper(traits_type::offset, wrapper.str)}, str{wrapper.str}
    {}
```
kinda mystified...
for dynamic strings, how does hashed_string work when its constructor is constexpr?