### PR TITLE
Allow hashed strings to be wide by defining ENTT_HS_WIDE.

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -11,6 +11,11 @@
 #define ENTT_HS_SUFFIX _hs
 #endif // ENTT_HS_SUFFIX
 
+#ifdef ENTT_HS_WIDE
+using hs_char_t = wchar_t;
+#else
+using hs_char_t = char;
+#endif // ENTT_HS_WIDE
 
 #ifndef ENTT_NO_ATOMIC
 #include <atomic>

--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -59,12 +59,12 @@ class hashed_string {
 
     struct const_wrapper {
         // non-explicit constructor on purpose
-        constexpr const_wrapper(const char *curr) ENTT_NOEXCEPT: str{curr} {}
-        const char *str;
+        constexpr const_wrapper(const hs_char_t *curr) ENTT_NOEXCEPT: str{curr} {}
+        const hs_char_t *str;
     };
 
     // Fowler–Noll–Vo hash function v. 1a - the good
-    inline static constexpr ENTT_ID_TYPE helper(ENTT_ID_TYPE partial, const char *curr) ENTT_NOEXCEPT {
+    inline static constexpr ENTT_ID_TYPE helper(ENTT_ID_TYPE partial, const hs_char_t *curr) ENTT_NOEXCEPT {
         return curr[0] == 0 ? partial : helper((partial^curr[0])*traits_type::prime, curr+1);
     }
 
@@ -77,18 +77,18 @@ public:
      *
      * Forcing template resolution avoids implicit conversions. An
      * human-readable identifier can be anything but a plain, old bunch of
-     * characters.<br/>
+     * hs_char_tacters.<br/>
      * Example of use:
      * @code{.cpp}
      * const auto value = hashed_string::to_value("my.png");
      * @endcode
      *
-     * @tparam N Number of characters of the identifier.
+     * @tparam N Number of hs_char_tacters of the identifier.
      * @param str Human-readable identifer.
      * @return The numeric representation of the string.
      */
     template<std::size_t N>
-    inline static constexpr hash_type to_value(const char (&str)[N]) ENTT_NOEXCEPT {
+    inline static constexpr hash_type to_value(const hs_char_t (&str)[N]) ENTT_NOEXCEPT {
         return helper(traits_type::offset, str);
     }
 
@@ -107,7 +107,7 @@ public:
      * @param size Length of the string to hash.
      * @return The numeric representation of the string.
      */
-    inline static hash_type to_value(const char *str, std::size_t size) ENTT_NOEXCEPT {
+    inline static hash_type to_value(const hs_char_t *str, std::size_t size) ENTT_NOEXCEPT {
         ENTT_ID_TYPE partial{traits_type::offset};
         while(size--) { partial = (partial^(str++)[0])*traits_type::prime; }
         return partial;
@@ -119,27 +119,27 @@ public:
     {}
 
     /**
-     * @brief Constructs a hashed string from an array of const chars.
+     * @brief Constructs a hashed string from an array of const hs_char_ts.
      *
      * Forcing template resolution avoids implicit conversions. An
      * human-readable identifier can be anything but a plain, old bunch of
-     * characters.<br/>
+     * hs_char_tacters.<br/>
      * Example of use:
      * @code{.cpp}
      * hashed_string hs{"my.png"};
      * @endcode
      *
-     * @tparam N Number of characters of the identifier.
+     * @tparam N Number of hs_char_tacters of the identifier.
      * @param curr Human-readable identifer.
      */
     template<std::size_t N>
-    constexpr hashed_string(const char (&curr)[N]) ENTT_NOEXCEPT
+    constexpr hashed_string(const hs_char_t (&curr)[N]) ENTT_NOEXCEPT
         : str{curr}, hash{helper(traits_type::offset, curr)}
     {}
 
     /**
      * @brief Explicit constructor on purpose to avoid constructing a hashed
-     * string directly from a `const char *`.
+     * string directly from a `const hs_char_t *`.
      * @param wrapper Helps achieving the purpose by relying on overloading.
      */
     explicit constexpr hashed_string(const_wrapper wrapper) ENTT_NOEXCEPT
@@ -150,7 +150,7 @@ public:
      * @brief Returns the human-readable representation of a hashed string.
      * @return The string used to initialize the instance.
      */
-    constexpr const char * data() const ENTT_NOEXCEPT {
+    constexpr const hs_char_t * data() const ENTT_NOEXCEPT {
         return str;
     }
 
@@ -166,7 +166,7 @@ public:
      * @brief Returns the human-readable representation of a hashed string.
      * @return The string used to initialize the instance.
      */
-    constexpr operator const char *() const ENTT_NOEXCEPT { return str; }
+    constexpr operator const hs_char_t *() const ENTT_NOEXCEPT { return str; }
 
     /*! @copydoc value */
     constexpr operator hash_type() const ENTT_NOEXCEPT { return hash; }
@@ -181,7 +181,7 @@ public:
     }
 
 private:
-    const char *str;
+    const hs_char_t *str;
     hash_type hash;
 };
 
@@ -205,7 +205,7 @@ constexpr bool operator!=(const hashed_string &lhs, const hashed_string &rhs) EN
  * @param str The literal without its suffix.
  * @return A properly initialized hashed string.
  */
-constexpr entt::hashed_string operator"" ENTT_HS_SUFFIX(const char *str, std::size_t) ENTT_NOEXCEPT {
+constexpr entt::hashed_string operator"" ENTT_HS_SUFFIX(const hs_char_t *str, std::size_t) ENTT_NOEXCEPT {
     return entt::hashed_string{str};
 }
 

--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -659,7 +659,7 @@ inline meta_type resolve() ENTT_NOEXCEPT {
  * @param str The name to use to search for a meta type.
  * @return The meta type associated with the given name, if any.
  */
-inline meta_type resolve(const char *str) ENTT_NOEXCEPT {
+inline meta_type resolve(const hs_char_t *str) ENTT_NOEXCEPT {
     const auto *curr = internal::find_if([name = hashed_string{str}](auto *node) {
         return node->name == name;
     }, internal::meta_info<>::type);

--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -1179,7 +1179,7 @@ public:
      * @brief Returns the name assigned to a given meta data.
      * @return The name assigned to the meta data.
      */
-    inline const char * name() const ENTT_NOEXCEPT {
+    inline const hs_char_t * name() const ENTT_NOEXCEPT {
         return node->name;
     }
 
@@ -1373,7 +1373,7 @@ public:
      * @brief Returns the name assigned to a given meta function.
      * @return The name assigned to the meta function.
      */
-    inline const char * name() const ENTT_NOEXCEPT {
+    inline const hs_char_t * name() const ENTT_NOEXCEPT {
         return node->name;
     }
 
@@ -1544,7 +1544,7 @@ public:
      * @brief Returns the name assigned to a given meta type.
      * @return The name assigned to the meta type.
      */
-    inline const char * name() const ENTT_NOEXCEPT {
+    inline const hs_char_t * name() const ENTT_NOEXCEPT {
         return node->name;
     }
 
@@ -1687,7 +1687,7 @@ public:
      * @param str The name to use to search for a meta base.
      * @return The meta base associated with the given name, if any.
      */
-    inline meta_base base(const char *str) const ENTT_NOEXCEPT {
+    inline meta_base base(const hs_char_t *str) const ENTT_NOEXCEPT {
         const auto *curr = internal::find_if<&internal::meta_type_node::base>([name = hashed_string{str}](auto *candidate) {
             return candidate->type()->name == name;
         }, node);
@@ -1787,7 +1787,7 @@ public:
      * @param str The name to use to search for a meta data.
      * @return The meta data associated with the given name, if any.
      */
-    inline meta_data data(const char *str) const ENTT_NOEXCEPT {
+    inline meta_data data(const hs_char_t *str) const ENTT_NOEXCEPT {
         const auto *curr = internal::find_if<&internal::meta_type_node::data>([name = hashed_string{str}](auto *candidate) {
             return candidate->name == name;
         }, node);
@@ -1822,7 +1822,7 @@ public:
      * @param str The name to use to search for a meta function.
      * @return The meta function associated with the given name, if any.
      */
-    inline meta_func func(const char *str) const ENTT_NOEXCEPT {
+    inline meta_func func(const hs_char_t *str) const ENTT_NOEXCEPT {
         const auto *curr = internal::find_if<&internal::meta_type_node::func>([name = hashed_string{str}](auto *candidate) {
             return candidate->name == name;
         }, node);


### PR DESCRIPTION
My project is using wide strings so I would like to use wide hashed strings.  I have therefore added configuration to change the use of char to hs_char_t which is either char or wchar_t (if ENTT_HS_WIDE is defined).

Please note I have fixed all occurrences of the use of char that my project saw however I did not go over the whole source tree to check the use of char.