### PR TITLE
fix UB in insertion_sort

### DIFF
--- a/src/entt/core/algorithm.hpp
+++ b/src/entt/core/algorithm.hpp
@@ -61,11 +61,16 @@ struct insertion_sort {
                 auto pre = it++;
                 auto value = *pre;
 
-                while(pre-- != first && compare(value, *pre)) {
+                while(compare(value, *--pre)) {
                     *(pre+1) = *pre;
+                    if (pre == first) {
+                        *pre = value;
+                        goto next;
+                    }
                 }
 
                 *(pre+1) = value;
+            next:;
             }
         }
     }


### PR DESCRIPTION
Look at https://github.com/skypjack/entt/blob/e088f0f31ea5a55f71446e75b659017e8e123333/src/entt/core/algorithm.hpp#L64
because of post-decrement, when pre becomes equal to first, there is an UB (we are decrementing an iterator at the beginning). With MSVC compiler it is not a problem in release build (because we actually do not dereference the iterator), but in debug build an assert is raised from iterator post decrement operator (to reproduce it is sufficient to run tests in debug mode).
The only solution i found (without rewriting all) needs to use a `goto`... but probably is possible to rewrite it better!