### PR TITLE
Conan: Support package in editable mode

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,5 +19,9 @@ class EnttConan(ConanFile):
         self.copy(pattern="LICENSE", dst="licenses")
         self.copy(pattern="*", dst="include", src="src", keep_path=True)
 
+    def package_info(self):
+        if not self.in_local_cache:
+            self.cpp_info.includedirs = ["src"]
+
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Add a method to the recipe that maps the include path to "src" when the package is put into "editable mode". See:
https://docs.conan.io/en/latest/developing_packages/editable_packages.html