### PR TITLE
Support move-only parameters in delegate

### DIFF
--- a/src/entt/signal/delegate.hpp
+++ b/src/entt/signal/delegate.hpp
@@ -101,16 +101,16 @@ class delegate;
  */
 template<typename Ret, typename... Args>
 class delegate<Ret(Args...)> {
-    using proto_fn_type = Ret(const void *, std::tuple<Args...>);
+    using proto_fn_type = Ret(const void *, std::tuple<Args &&...>);
 
     template<auto Function, std::size_t... Index>
     void connect(std::index_sequence<Index...>) ENTT_NOEXCEPT {
         data = nullptr;
 
-        fn = [](const void *, std::tuple<Args...> args) -> Ret {
+        fn = [](const void *, std::tuple<Args &&...> args) -> Ret {
             static_assert(std::is_invocable_r_v<Ret, decltype(Function), std::tuple_element_t<Index, std::tuple<Args...>>...>);
             // Ret(...) allows void(...) to eat return values and avoid errors
-            return Ret(std::invoke(Function, std::get<Index>(args)...));
+            return Ret(std::invoke(Function, std::forward<std::tuple_element_t<Index, std::tuple<Args...>>>(std::get<Index>(args))...));
         };
     }
 
@@ -118,7 +118,7 @@ class delegate<Ret(Args...)> {
     void connect(Type *value_or_instance, std::index_sequence<Index...>) ENTT_NOEXCEPT {
         data = value_or_instance;
 
-        fn = [](const void *payload, std::tuple<Args...> args) -> Ret {
+        fn = [](const void *payload, std::tuple<Args &&...> args) -> Ret {
             Type *curr = nullptr;
 
             if constexpr(std::is_const_v<Type>) {
@@ -129,7 +129,7 @@ class delegate<Ret(Args...)> {
 
             static_assert(std::is_invocable_r_v<Ret, decltype(Candidate), Type *, std::tuple_element_t<Index, std::tuple<Args...>>...>);
             // Ret(...) allows void(...) to eat return values and avoid errors
-            return Ret(std::invoke(Candidate, curr, std::get<Index>(args)...));
+            return Ret(std::invoke(Candidate, curr, std::forward<std::tuple_element_t<Index, std::tuple<Args...>>>(std::get<Index>(args))...));
         };
     }
 
@@ -232,7 +232,7 @@ public:
      */
     Ret operator()(Args... args) const {
         ENTT_ASSERT(fn);
-        return fn(data, std::forward_as_tuple(args...));
+        return fn(data, std::tuple<Args &&...>(std::forward<Args>(args)...));
     }
 
     /**


### PR DESCRIPTION
I had a look at `std::function` and basically did what it does.

Here is the implementation of `std::function::operator()`.

```C++
template<class _Rp, class ..._ArgTypes>
_Rp
function<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __arg) const
{
    if (__f_ == 0)
        __throw_bad_function_call();
    return (*__f_)(_VSTD::forward<_ArgTypes>(__arg)...);
}
```

`__f_` is declared as a `__base *` which has a call operator declared like this:

```C++
virtual _Rp operator()(_ArgTypes&& ...) = 0;
```

The changes were inspired by `std::function` but it was really just a whole lot of fiddling around until I got the tests to pass!

I made these changes on wip because I saw that you already made changes to delegate on wip and I didn't want to create a merge conflict.