### PR TITLE
batch stomp imp and test

### DIFF
--- a/src/entt/entity/actor.hpp
+++ b/src/entt/entity/actor.hpp
@@ -10,7 +10,6 @@
 #include "entity.hpp"
 #include "fwd.hpp"
 
-
 namespace entt {
 
 
@@ -174,6 +173,7 @@ struct basic_actor {
         return entt;
     }
 
+
     /**
      * @brief Checks if an actor refers to a valid entity or not.
      * @return True if the actor refers to a valid entity, false otherwise.
@@ -185,6 +185,48 @@ struct basic_actor {
 private:
     registry_type *reg;
     entity_type entt;
+};
+
+template<typename Entity>
+class basic_proto_actor : public basic_actor<Entity> {
+
+    /*! @brief Type of registry used internally. */
+    using registry_type = basic_registry<Entity>;
+    /*! @brief Underlying entity identifier. */
+    using entity_type = Entity;
+
+public:
+    explicit basic_proto_actor(registry_type &ref)
+        : basic_actor<Entity>(ref)
+    {}
+    basic_proto_actor() ENTT_NOEXCEPT
+    {}
+
+    /**
+     * @brief create new prototype actor using same registry, and stomp
+     *     desired components to it. This is meant to allow for creating 
+     *     prototype factories derived from eachother.
+     */
+    template<typename... Component, typename... Exclude>
+    basic_proto_actor copy(exclude_t<Exclude...> exclude = {}) {
+        auto n = basic_proto_actor(basic_actor<Entity>::backend());
+        stomp<Component...>(basic_actor<Entity>::backend(), n.entity());
+        return std::move(n);
+    }
+    /**
+     * @brief Wraps registry batch_stomp
+     */
+    template<typename... Component, typename... Exclude>
+    void stomp(registry_type &other, const entity_type to, exclude_t<Exclude...> exclude = {}) {
+        basic_actor<Entity>::backend().template stomp<Component...>(entity(), other, to, exclude);
+    }
+    /**
+     * @brief Wraps registry batch_stomp
+     */
+    template<typename... Component, typename It, typename... Exclude>
+    void batch_stomp(registry_type &other, It first, It last, exclude_t<Exclude...> exclude = {}) {
+        basic_actor<Entity>::backend().template stomp<Component...>(entity(), other, first, last, exclude);
+    }
 };
 
 

--- a/src/entt/entity/fwd.hpp
+++ b/src/entt/entity/fwd.hpp
@@ -33,6 +33,9 @@ class basic_observer;
 template <typename>
 struct basic_actor;
 
+template <typename>
+struct basic_proto_actor;
+
 /*! @class basic_prototype */
 template<typename>
 class basic_prototype;
@@ -63,6 +66,7 @@ using observer = basic_observer<entity>;
 
 /*! @brief Alias declaration for the most common use case. */
 using actor = basic_actor<entity>;
+using proto_actor = basic_proto_actor<entity>;
 
 /*! @brief Alias declaration for the most common use case. */
 using prototype = basic_prototype<entity>;

--- a/test/entt/entity/actor.cpp
+++ b/test/entt/entity/actor.cpp
@@ -40,6 +40,30 @@ TEST(Actor, Component) {
     ASSERT_FALSE(actor.has<int>());
 }
 
+TEST(Actor, ProtoActor) {
+    entt::registry registry;
+
+    auto proto = entt::proto_actor{registry};
+    proto.assign<int>(2);
+
+    auto proto2 = proto.copy();
+    ASSERT_TRUE(proto.has<int>());
+    ASSERT_TRUE(proto2.has<int>());
+    ASSERT_EQ(registry.size(), 2);
+
+    proto.assign<int>(3);
+    ASSERT_EQ(proto2.get<int>(), 2);
+
+    ASSERT_TRUE(proto);
+    ASSERT_FALSE(registry.empty<int>());
+    ASSERT_FALSE(registry.empty());
+
+    registry.destroy(proto.entity());
+
+    ASSERT_FALSE(proto);
+    ASSERT_TRUE(proto2);
+}
+
 TEST(Actor, EntityLifetime) {
     entt::registry registry;
     entt::actor actor{};

--- a/test/entt/entity/registry.cpp
+++ b/test/entt/entity/registry.cpp
@@ -1440,6 +1440,37 @@ TEST(Registry, Stomp) {
     ASSERT_EQ(registry.get<char>(other), 'c');
 }
 
+
+TEST(Registry, StompBatch) {
+    entt::registry registry;
+
+    const auto entity = registry.create();
+    registry.assign<int>(entity, 3);
+    registry.assign<char>(entity, 'c');
+
+    std::vector<entt::entity> entities(1000);
+    registry.create(entities.begin(), entities.end());
+    registry.batch_stomp<int, char, double>(
+        entity, registry, entities.begin(), entities.end());
+
+    ASSERT_TRUE(std::all_of(entities.begin(), entities.end(), 
+        [&registry](auto other) {return registry.get<int>(other) == 3;}));
+    ASSERT_TRUE(std::all_of(entities.begin(), entities.end(), 
+        [&registry](auto other) {return registry.get<char>(other) == 'c';}));
+
+    registry.replace<int>(entity, 42);
+    registry.replace<char>(entity, 'a');
+
+    registry.batch_stomp(
+        entity, registry, entities.begin(), entities.end());
+
+    ASSERT_TRUE(std::all_of(entities.begin(), entities.end(), 
+        [&registry](auto other) {return registry.get<int>(other) == 42;}));
+    ASSERT_TRUE(std::all_of(entities.begin(), entities.end(), 
+        [&registry](auto other) {return registry.get<char>(other) == 'a';}));
+}
+
+
 TEST(Registry, StompExclude) {
     entt::registry registry;
 


### PR DESCRIPTION
expand on stomp but iterate the range within the if conditional so that we're not repeatedly doing the run-time conditional check on each pool.