### PR TITLE
Mark CMake project explicitly as C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Project configuration
 #
 
-project(EnTT VERSION 3.2.0)
+project(EnTT VERSION 3.2.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This prevents checking of C compiler