### PR TITLE
Fix entt::collector.where

### DIFF
--- a/src/entt/entity/observer.hpp
+++ b/src/entt/entity/observer.hpp
@@ -83,7 +83,7 @@ struct basic_collector<matcher<matcher<type_list<Reject...>, type_list<Require..
     template<typename... AllOf, typename... NoneOf>
     static constexpr auto group(exclude_t<NoneOf...> = {}) ENTT_NOEXCEPT {
         using first = matcher<matcher<type_list<Reject...>, type_list<Require...>>, Rule...>;
-        return basic_collector<first, Other..., matcher<matcher<type_list<>, type_list<>>, type_list<NoneOf...>, type_list<AllOf...>>>{};
+        return basic_collector<matcher<matcher<type_list<>, type_list<>>, type_list<NoneOf...>, type_list<AllOf...>>, first, Other...>{};
     }
 
     /**
@@ -94,7 +94,7 @@ struct basic_collector<matcher<matcher<type_list<Reject...>, type_list<Require..
     template<typename AnyOf>
     static constexpr auto replace() ENTT_NOEXCEPT {
         using first = matcher<matcher<type_list<Reject...>, type_list<Require...>>, Rule...>;
-        return basic_collector<first, Other..., matcher<matcher<type_list<>, type_list<>>, AnyOf>>{};
+        return basic_collector<matcher<matcher<type_list<>, type_list<>>, AnyOf>, first, Other...>{};
     }
 
     /**

--- a/test/entt/entity/observer.cpp
+++ b/test/entt/entity/observer.cpp
@@ -130,6 +130,72 @@ TEST(Observer, AllOfFiltered) {
     ASSERT_TRUE(observer.empty());
 }
 
+TEST(Observer, WhereChain) {
+    constexpr auto collector =  entt::collector
+            .replace<int>().where<char>()
+            .replace<double>().where<float>();
+
+    entt::registry registry;
+    entt::observer observer{registry, collector};
+    const auto entity = registry.create();
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign<int>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign_or_replace<int>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign<char>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign_or_replace<int>(entity);
+
+    ASSERT_EQ(observer.size(), entt::observer::size_type{ 1 });
+    ASSERT_FALSE(observer.empty());
+    ASSERT_EQ(*observer.data(), entity);
+
+    observer.clear();
+    registry.assign<double>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign_or_replace<double>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign<float>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign_or_replace<double>(entity);
+
+    ASSERT_EQ(observer.size(), entt::observer::size_type{ 1 });
+    ASSERT_FALSE(observer.empty());
+    ASSERT_EQ(*observer.data(), entity);
+
+    registry.remove<float>(entity);
+
+    ASSERT_TRUE(observer.empty());
+
+    registry.assign_or_replace<int>(entity);
+
+    ASSERT_EQ(observer.size(), entt::observer::size_type{ 1 });
+    ASSERT_FALSE(observer.empty());
+    ASSERT_EQ(*observer.data(), entity);
+
+    observer.clear();
+    observer.disconnect();
+
+    registry.assign_or_replace<int>(entity);
+
+    ASSERT_TRUE(observer.empty());
+}
+
 TEST(Observer, Observe) {
     entt::registry registry;
     entt::observer observer{registry, entt::collector.replace<int>().replace<char>()};


### PR DESCRIPTION
Hello! I think `entt::collector` has a bug. The `where` function actually changes the first added matcher, not the last one. In the following example both of `where` calls update the `group` matcher instead of preceding `replace` matcher.

```
entt::observer(registry, entt::collector.group<ComponentA, ComponentB>()
                                        .replace<ComponentA>().where<ComponentA, ComponentB>()
                                        .replace<ComponentB>().where<ComponentA, ComponentB>())
```

Here's the fix.