### PR TITLE
Add namespace qualifier in CMake (close #321)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 #
 
 add_library(EnTT INTERFACE)
+add_library(EnTT::EnTT ALIAS EnTT)
 
 configure_file(${EnTT_SOURCE_DIR}/cmake/in/version.h.in ${EnTT_SOURCE_DIR}/src/entt/config/version.h @ONLY)
 
@@ -123,6 +124,7 @@ install(
     EXPORT EnTTTargets
     FILE EnTTTargets.cmake
     DESTINATION ${CUSTOM_INSTALL_CONFIGDIR}
+    NAMESPACE EnTT::
 )
 
 #


### PR DESCRIPTION
- Adds an alias to the library for in-source builds. IE: `add_subdirectory`
- Adds a namespace to the exported library so it also works with `find_package` and any other scenario where you don't build in-source

Tested on real world project wacman to both changes above and it built as expected.