### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ open an issue to discuss your idea.
 
 To be able to use `EnTT`, users must provide a full-featured compiler that
 supports at least C++17.<br/>
+
+You can download and install `EnTT` using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install entt
+
+The `EnTT` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 The requirements below are mandatory to compile the tests and to extract the
 documentation:
 


### PR DESCRIPTION
EnTT is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for EnTT and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build EnTT, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/entt/portfile.cmake). We try to keep the library maintained as close as possible to the original library.