### PR TITLE
Intoduced a macro for suppressing MSVC warning C4307

### DIFF
--- a/docs/md/faq.md
+++ b/docs/md/faq.md
@@ -128,10 +128,8 @@ here is a workaround in the form of a macro:
 ```cpp
 #if defined(_MSC_VER)
     #define HS(str)\
-        __pragma(warning(push))\
-        __pragma(warning(disable:4307))\
+        __pragma(warning(suppress:4307))\
         entt::hashed_string{str}\
-        __pragma(warning(pop))
 #else
     #define HS(str) entt::hashed_string{str}
 #endif
@@ -144,6 +142,16 @@ constexpr auto identifier = HS("my/resource/identifier");
 ```
 
 Thanks to [huwpascoe](https://github.com/huwpascoe) for the courtesy.
+
+Alternatively it is possible to use the macro provided by EnTT:
+
+```cpp
+ #define HS(str) ENTT_HASHED_STRING_SUPPRESS_WARNING entt::hashed_string{str}
+```
+
+This macro can be used in all cases where `entt::hashed_string` is used in
+constexpr context, for example, when specialising the `entt::named_type_traits`
+class.
 
 ## Warning C4003: the min, the max and the macro
 

--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -6,6 +6,14 @@
 #include "../config/config.h"
 
 
+#if defined(_MSC_VER)
+#   define ENTT_HASHED_STRING_SUPPRESS_WARNING                                \
+        __pragma (warning (suppress : 4307))
+#else
+#   define ENTT_HASHED_STRING_SUPPRESS_WARNING
+#endif
+
+
 namespace entt {
 
 

--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -269,7 +269,7 @@ constexpr auto is_named_type_v = is_named_type<Type>::value;
 #define ENTT_NAMED_TYPE(type)\
     template<>\
     struct entt::named_type_traits<type>\
-        : std::integral_constant<ENTT_ID_TYPE, entt::basic_hashed_string<std::remove_cv_t<std::remove_pointer_t<std::decay_t<decltype(#type)>>>>{#type}>\
+        : std::integral_constant<ENTT_ID_TYPE, ENTT_HASHED_STRING_SUPPRESS_WARNING entt::basic_hashed_string<std::remove_cv_t<std::remove_pointer_t<std::decay_t<decltype(#type)>>>>{#type}>\
     {\
         static_assert(std::is_same_v<std::remove_cv_t<type>, type>);\
         static_assert(std::is_object_v<type>);\


### PR DESCRIPTION
The new macro can be used in user code for suppressing warnings when using
entt::hashed_string in constexpr context. The workaround provided in the FAQ

```c++
  #define HS(str)\
  __pragma(warning(push))\
  __pragma(warning(disable:4307))\
  entt::hashed_string{str}\
  __pragma(warning(pop))
  #define HS(str) entt::hashed_string{str}
```

can be reduced to

```c++
  #define HS(str) ENTT_HASHED_STRING_SUPPRESS_WARNING entt::hashed_string{str}
```

The new macro is also applied in the `ENTT_NAMED_TYPE` macro to reduce the
number of false warnings in user code. It is suggested that users should use
the macro also in their own specialisation of the `entt::named_type_traits`
template class.

The documentation was updated to mention a simplified form of warning
suppression and the newly added macro.

closes #348