### PR TITLE
adding git_shallow to cmake deps helps reducing building time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ NixAJ
 Paolo-Oliverio
 pgruenbacher
 prowolf
+stefanofiorentino
 suVrik
 szunhammer
 The5-1

--- a/cmake/in/cereal.in
+++ b/cmake/in/cereal.in
@@ -7,6 +7,7 @@ ExternalProject_Add(
     cereal
     GIT_REPOSITORY https://github.com/USCiLab/cereal.git
     GIT_TAG v1.2.2
+    GIT_SHALLOW 1
     DOWNLOAD_DIR ${CEREAL_DEPS_DIR}
     TMP_DIR ${CEREAL_DEPS_DIR}/tmp
     STAMP_DIR ${CEREAL_DEPS_DIR}/stamp

--- a/cmake/in/duktape.in
+++ b/cmake/in/duktape.in
@@ -7,6 +7,7 @@ ExternalProject_Add(
     duktape
     GIT_REPOSITORY https://github.com/svaarala/duktape-releases.git
     GIT_TAG v2.2.0
+    GIT_SHALLOW 1
     DOWNLOAD_DIR ${DUKTAPE_DEPS_DIR}
     TMP_DIR ${DUKTAPE_DEPS_DIR}/tmp
     STAMP_DIR ${DUKTAPE_DEPS_DIR}/stamp

--- a/cmake/in/googletest.in
+++ b/cmake/in/googletest.in
@@ -7,6 +7,7 @@ ExternalProject_Add(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG master
+    GIT_SHALLOW 1
     DOWNLOAD_DIR ${GOOGLETEST_DEPS_DIR}
     TMP_DIR ${GOOGLETEST_DEPS_DIR}/tmp
     STAMP_DIR ${GOOGLETEST_DEPS_DIR}/stamp


### PR DESCRIPTION
	very useful in CI/CD pipelines

Signed-off-by: Stefano Fiorentino <stefano.fiore84@gmail.com>