### PR TITLE
Fix MSVC non-member template functions compilation error

### DIFF
--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -90,7 +90,7 @@ bool setter([[maybe_unused]] meta_handle handle, [[maybe_unused]] meta_any index
     bool accepted = false;
 
     if constexpr(!Const) {
-        if constexpr(std::is_function_v<std::remove_pointer_t<decltype(Data)>> || std::is_member_function_pointer_v<decltype(Data)>) {
+        if constexpr(std::is_function_v<std::remove_reference_t<std::remove_pointer_t<decltype(Data)>>> || std::is_member_function_pointer_v<decltype(Data)>) {
             using helper_type = meta_function_helper_t<decltype(Data)>;
             using data_type = std::tuple_element_t<!std::is_member_function_pointer_v<decltype(Data)>, typename helper_type::args_type>;
             static_assert(std::is_invocable_v<decltype(Data), Type &, data_type>);
@@ -164,7 +164,7 @@ meta_any getter([[maybe_unused]] meta_handle handle, [[maybe_unused]] meta_any i
         }
     };
 
-    if constexpr(std::is_function_v<std::remove_pointer_t<decltype(Data)>> || std::is_member_function_pointer_v<decltype(Data)>) {
+    if constexpr(std::is_function_v<std::remove_reference_t<std::remove_pointer_t<decltype(Data)>>> || std::is_member_function_pointer_v<decltype(Data)>) {
         static_assert(std::is_invocable_v<decltype(Data), Type &>);
         auto * const clazz = meta_any{handle}.try_cast<Type>();
         return clazz ? dispatch(std::invoke(Data, *clazz)) : meta_any{};
@@ -218,7 +218,7 @@ meta_any invoke([[maybe_unused]] meta_handle handle, meta_any *args, std::index_
         return instance;
     }(args+Indexes, (args+Indexes)->try_cast<std::tuple_element_t<Indexes, typename helper_type::args_type>>())...);
 
-    if constexpr(std::is_function_v<std::remove_pointer_t<decltype(Candidate)>>) {
+    if constexpr(std::is_function_v<std::remove_reference_t<std::remove_pointer_t<decltype(Candidate)>>>) {
         return (std::get<Indexes>(direct) && ...) ? dispatch(std::get<Indexes>(direct)...) : meta_any{};
     } else {
         auto * const clazz = meta_any{handle}.try_cast<Type>();


### PR DESCRIPTION
Hey! With a recent MSVC update my project fails to compile because I use non-member template functions in EnTT reflection. For whatever reason MSVC considers these functions to be references rather than pointers. EnTT tests fail to compile as well, even though non-member template `func` is not covered (non-member template setters and getters are). Here's the fix for this issue. I added tests for both member template functions and non-member ones just in case of future MSVC surprises. Cheers