### PR TITLE
Fix for #407 - vs2017 warning:  warning C4172: returning address of local va…

### DIFF
--- a/src/entt/entity/storage.hpp
+++ b/src/entt/entity/storage.hpp
@@ -286,6 +286,25 @@ public:
     }
 
     /**
+     * @brief Replaces the object associated with an entity.
+     *
+     * @warning
+     * Attempting to use an entity that doesn't belong to the storage results in
+     * undefined behavior.<br/>
+     * An assertion will abort the execution at runtime in debug mode if the
+     * storage doesn't contain the given entity.
+     *
+     * @param entt A valid entity identifier.
+     * @param object - the replacement component
+     * @return The new object associated with the entity.
+     */
+    object_type & replace(const entity_type entt, object_type&& object)
+    {
+        return get(entt) = std::move(object);
+    }
+
+
+    /**
      * @brief Returns a pointer to the object associated with an entity, if any.
      * @param entt A valid entity identifier.
      * @return The object associated with the entity, if any.
@@ -641,6 +660,28 @@ public:
     object_type get([[maybe_unused]] const entity_type entt) const {
         ENTT_ASSERT(underlying_type::has(entt));
         return {};
+    }
+
+    /**
+    * @brief Replaces the object associated with an entity.
+    *
+    * @note
+    * Empty types aren't explicitly instantiated. Therefore, this function
+    * always returns what is passed in.
+    *
+    * @warning
+    * Attempting to use an entity that doesn't belong to the storage results in
+    * undefined behavior.<br/>
+    * An assertion will abort the execution at runtime in debug mode if the
+    * storage doesn't contain the given entity.
+    *
+    * @param entt A valid entity identifier.
+    * @param object The 'replacement' object 
+    * @return The object associated with the entity.
+    */
+    object_type replace([[maybe_unused]] const entity_type entt, object_type&& object) const {
+        ENTT_ASSERT(underlying_type::has(entt));
+        return object;
     }
 
     /**


### PR DESCRIPTION
Fix for #407 :  vs2017 warning:  warning C4172: returning address of local variable or temporary

When given an empty type registry::pool_manager::replace calls storage::get which returns by value,
operator= then returns a reference to that temporary value which is then returned from replace triggering the warning.
I moved the assignment code from registry::pool_manager::replace down into storage class by adding a replace function to storage
This means the 'assignment' is done before returning the value or ref from the storage class.
