### PR TITLE
Re-added bazel support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,15 @@
+_msvc_copts = ["/std:c++17"]	
+_gcc_copts = ["-std=c++17"]
+
+cc_library(
+    name = "entt",
+    visibility = ["//visibility:public"],
+    strip_include_prefix = "src",
+    hdrs = glob(["src/**/*.h", "src/**/*.hpp"]),
+    copts = select({
+      "@bazel_tools//src/conditions:windows": _msvc_copts,
+      "@bazel_tools//src/conditions:windows_msvc": _msvc_copts,
+      "@bazel_tools//src/conditions:windows_msys": _msvc_copts,
+      "//conditions:default": _gcc_copts,
+    }),
+)

--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ documentation:
 * `CMake` version 3.7 or later.
 * `Doxygen` version 1.8 or later.
 
+Alternatively, [Bazel](https://bazel.build) is also supported as a build system
+(credits to [zaucy](https://github.com/zaucy) who offered to maintain it.)<br/>
+In the documentation below I'll still refer to `CMake`, this being the official
+build system of the library.
+
 If you are looking for a C++14 version of `EnTT`, check out the git tag `cpp14`.
 
 ## Library

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_github_skypjack_entt")


### PR DESCRIPTION
Hey it's me again the bazel guy.

I was updating my project to the latest version of EnTT (v3.3.0) and noticed it no longer worked with bazel! I see it was removed due to it not being maintained. I'll admit I hadn't been running the tests so I didn't notice that shortly after it was initially added the tests no longer worked with bazel. However my project had been running EnTT v3.2.2 just fine because the user facing target `@com_github_skypjack_entt//:entt` had been working.

So that brings us to this PR. This PR includes only the user facing target and no tests to make it simpler.