### PR TITLE
Update clone example to handle empty types

### DIFF
--- a/docs/md/entity.md
+++ b/docs/md/entity.md
@@ -701,7 +701,11 @@ A general purpose cloning function could be defined as:
 ```cpp
 template<typename Type>
 void clone(const entt::registry &from, entt::registry &to) {
+  if constexpr(ENTT_ENABLE_ETO(Type)) {
+    to.assign<Type>(from.data<Type>(), from.data<Type>() + from.size<Type>());
+  } else {
     to.assign<Type>(from.data<Type>(), from.data<Type>() + from.size<Type>(), from.raw<Type>());
+  }
 }
 ```
 


### PR DESCRIPTION
example should match how legacy EnTT worked, raw isn't available for empty types.