### PR TITLE
Calling a meta function with entt::meta_any as parameter

### DIFF
--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -212,6 +212,8 @@ meta_any invoke([[maybe_unused]] meta_any instance, meta_any *args, std::index_s
     [[maybe_unused]] const auto direct = std::make_tuple([](meta_any *any, auto *value) {
         using arg_type = std::remove_reference_t<decltype(*value)>;
 
+        if constexpr (std::is_same_v<arg_type, entt::meta_any>)
+            return any;
         if(!value && any->convert<arg_type>()) {
             value = any->try_cast<arg_type>();
         }


### PR DESCRIPTION
Hello !

This patch check in the parameter tuple constructor if the target parameter type is **entt::meta_any** thus skip any conversion.

This simple example shows the issue that I tried to fix. If you try to run it, you will see that foo is never called.
```C++
#include <iostream>
#include <entt/meta/meta.hpp>
#include <entt/meta/factory.hpp>

struct MyStruct
{
    void foo(const entt::meta_any &any) { std::cout << "Foo called " << any.cast<int>() << std::endl;}
};

int main(void)
{
    using namespace entt; // '_hs' hash literal

    entt::meta<MyStruct>()
        .alias("MyStruct"_hs)
        .func<&MyStruct::foo>("foo"_hs);

    MyStruct myStruct;
    entt::meta_any var { 42 };

    entt::resolve<MyStruct>().func("foo"_hs).invoke(myStruct, var);
}
```