### PR TITLE
Fix small typo in docs

### DIFF
--- a/docs/md/entity.md
+++ b/docs/md/entity.md
@@ -250,7 +250,7 @@ registry.emplace_or_replace<position>(entity, 0., 0.);
 This is a slightly faster alternative for the following snippet:
 
 ```cpp
-if(registry.has<comp>(entity)) {
+if(registry.has<velocity>(entity)) {
     registry.replace<velocity>(entity, 0., 0.);
 } else {
     registry.emplace<velocity>(entity, 0., 0.);


### PR DESCRIPTION
Hello.

I've fixed a small typo in docs (need to check if entity has `velocity` component, not `comp` component).