### PR TITLE
snapshot: components no longer need to be copyable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ skypjack
 
 # Contributors
 
+alexames
 BenediktConze
 bjadamson
 ceeac

--- a/src/entt/entity/snapshot.hpp
+++ b/src/entt/entity/snapshot.hpp
@@ -184,7 +184,7 @@ class basic_snapshot_loader {
                 archive(entt, instance);
                 const auto entity = reg->valid(entt) ? entt : reg->create(entt);
                 ENTT_ASSERT(entity == entt);
-                reg->template emplace<Type>(args..., entt, std::as_const(instance));
+                reg->template emplace<Type>(args..., entt, std::move(instance));
             }
         }
     }
@@ -395,7 +395,7 @@ class basic_continuous_loader {
                 archive(entt, instance);
                 (update(instance, member), ...);
                 restore(entt);
-                reg->template emplace_or_replace<Other>(map(entt), std::as_const(instance));
+                reg->template emplace_or_replace<Other>(map(entt), std::move(instance));
             }
         }
     }

--- a/test/entt/entity/snapshot.cpp
+++ b/test/entt/entity/snapshot.cpp
@@ -8,6 +8,19 @@
 #include <entt/entity/snapshot.hpp>
 #include <entt/entity/entity.hpp>
 
+struct noncopyable_component {
+    noncopyable_component() : foo{} {}
+    explicit noncopyable_component(int foo) : foo{foo} {}
+
+    noncopyable_component(const noncopyable_component&) = delete;
+    noncopyable_component& operator=(const noncopyable_component&) = delete;
+
+    noncopyable_component(noncopyable_component&&) = default;
+    noncopyable_component& operator=(noncopyable_component&&) = default;
+
+    long foo;
+};
+
 template<typename Storage>
 struct output_archive {
     output_archive(Storage &instance)
@@ -17,6 +30,10 @@ struct output_archive {
     template<typename... Value>
     void operator()(const Value &... value) {
         (std::get<std::queue<Value>>(storage).push(value), ...);
+    }
+    
+    void operator()(const entt::entity &entity, const noncopyable_component &value) {
+        (*this)(entity, value.foo);
     }
 
 private:
@@ -38,6 +55,10 @@ struct input_archive {
         };
 
         (assign(value), ...);
+    }
+    
+    void operator()(entt::entity &entity, noncopyable_component &value) {
+        (*this)(entity, value.foo);
     }
 
 private:
@@ -207,6 +228,7 @@ TEST(Snapshot, Iterator) {
     for(auto i = 0; i < 50; ++i) {
         const auto entity = registry.create();
         registry.emplace<another_component>(entity, i, i);
+        registry.emplace<noncopyable_component>(entity, i);
 
         if(i % 2) {
             registry.emplace<a_component>(entity);
@@ -216,7 +238,8 @@ TEST(Snapshot, Iterator) {
     using storage_type = std::tuple<
         std::queue<typename traits_type::entity_type>,
         std::queue<entt::entity>,
-        std::queue<another_component>
+        std::queue<another_component>,
+        std::queue<long>
     >;
 
     storage_type storage;
@@ -226,9 +249,9 @@ TEST(Snapshot, Iterator) {
     const auto view = registry.view<a_component>();
     const auto size = view.size();
 
-    entt::snapshot{registry}.component<another_component>(output, view.begin(), view.end());
+    entt::snapshot{registry}.component<another_component, noncopyable_component>(output, view.begin(), view.end());
     registry.clear();
-    entt::snapshot_loader{registry}.component<another_component>(input);
+    entt::snapshot_loader{registry}.component<another_component, noncopyable_component>(input);
 
     ASSERT_EQ(registry.view<another_component>().size(), size);
 
@@ -254,6 +277,7 @@ TEST(Snapshot, Continuous) {
         std::queue<another_component>,
         std::queue<what_a_component>,
         std::queue<map_component>,
+        std::queue<long>,
         std::queue<double>
     >;
 
@@ -273,6 +297,7 @@ TEST(Snapshot, Continuous) {
 
         src.emplace<a_component>(entity);
         src.emplace<another_component>(entity, i, i);
+        src.emplace<noncopyable_component>(entity, i);
 
         if(i % 2) {
             src.emplace<what_a_component>(entity, entity);
@@ -296,11 +321,12 @@ TEST(Snapshot, Continuous) {
     entity = dst.create();
     dst.emplace<a_component>(entity);
     dst.emplace<another_component>(entity, -1, -1);
+    dst.emplace<noncopyable_component>(entity, -1);
 
-    entt::snapshot{src}.entities(output).component<a_component, another_component, what_a_component, map_component>(output);
+    entt::snapshot{src}.entities(output).component<a_component, another_component, what_a_component, map_component, noncopyable_component>(output);
 
     loader.entities(input)
-        .component<a_component, another_component, what_a_component, map_component>(
+        .component<a_component, another_component, what_a_component, map_component, noncopyable_component>(
             input,
             &what_a_component::bar,
             &what_a_component::quux,
@@ -313,6 +339,7 @@ TEST(Snapshot, Continuous) {
     decltype(dst.size()) another_component_cnt{};
     decltype(dst.size()) what_a_component_cnt{};
     decltype(dst.size()) map_component_cnt{};
+    decltype(dst.size()) noncopyable_component_cnt{};
 
     dst.each([&dst, &a_component_cnt](auto entt) {
         ASSERT_TRUE(dst.has<a_component>(entt));
@@ -351,6 +378,10 @@ TEST(Snapshot, Continuous) {
         ++map_component_cnt;
     });
 
+    dst.view<noncopyable_component>().each([&noncopyable_component_cnt](auto entt, const auto &component) {
+        ++noncopyable_component_cnt;
+    });
+
     src.view<another_component>().each([](auto, auto &component) {
         component.value = 2 * component.key;
     });
@@ -375,6 +406,7 @@ TEST(Snapshot, Continuous) {
     ASSERT_EQ(dst.size<another_component>(), another_component_cnt);
     ASSERT_EQ(dst.size<what_a_component>(), what_a_component_cnt);
     ASSERT_EQ(dst.size<map_component>(), map_component_cnt);
+    ASSERT_EQ(dst.size<noncopyable_component>(), noncopyable_component_cnt);
 
     dst.view<another_component>().each([](auto, auto &component) {
         ASSERT_EQ(component.value, component.key < 0 ? -1 : (2 * component.key));


### PR DESCRIPTION
Replaced calls to std::as_const with std::move so that components can
be moved into place instead of copied when reading them in from a
snapshot.