### PR TITLE
Fix C4003 NOMINMAX bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ ceeac
 ColinH
 corystegel
 Croydon
+cugone
 dbacchet
 dBagrat
 djarek

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -240,7 +240,7 @@ class basic_view<Entity, exclude_t<Exclude...>, Component...> {
     {}
 
     [[nodiscard]] const sparse_set<Entity> & candidate() const ENTT_NOEXCEPT {
-        return *std::min({ static_cast<const sparse_set<Entity> *>(std::get<pool_type<Component> *>(pools))... }, [](const auto *lhs, const auto *rhs) {
+        return *(std::min)({ static_cast<const sparse_set<Entity> *>(std::get<pool_type<Component> *>(pools))... }, [](const auto *lhs, const auto *rhs) {
             return lhs->size() < rhs->size();
         });
     }
@@ -320,7 +320,7 @@ public:
      * @return Estimated number of entities iterated by the view.
      */
     [[nodiscard]] size_type size() const ENTT_NOEXCEPT {
-        return std::min({ std::get<pool_type<Component> *>(pools)->size()... });
+        return (std::min)({ std::get<pool_type<Component> *>(pools)->size()... });
     }
 
     /**


### PR DESCRIPTION
Closes #530
Closes #96 

This fixes the `std::min` and `std::max` functions being parsed as macros when `<windows.h>` is included and `#define NOMINMAX` is neither present nor included before all other headers.

Note: There is a use of `std::max` in the single-include header that does not appear anywhere else in the separated-out code. I could not find where the single-include header is generated to see where it's coming from.