### PR TITLE
Truly invalid entt::handle

### DIFF
--- a/docs/md/entity.md
+++ b/docs/md/entity.md
@@ -674,10 +674,15 @@ the requested method, passing on the arguments if necessary.
 
 ### Handle
 
-A handle is a thin wrapper around an entity and a registry. It provides the same
-functions that the registry offers for working with components, such as
+A handle is a thin wrapper around an entity and a registry. It provides the
+same functions that the registry offers for working with components, such as
 `emplace`, `get`, `patch`, `remove` and so on. The difference being that the
 entity is implicitly passed to the registry.<br/>
+It's default constructible as an invalid handle that contains a null registry
+and a null entity. When it contains a null registry calling functions that
+delegate execution to the registry will cause a crash, so it's recommended to
+check the validity of the handle with implicit cast to `bool` when in doubt.
+<br/>
 A handle is also non-owning, meaning that it can be freely copied and moved
 around without affecting its entity (in fact, handles happen to be trivially
 copyable). An implication of this is that mutability becomes part of the

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -9,18 +9,18 @@ namespace entt {
 
 
 /**
-* @brief Non-owning handle to an entity.
-*
-* Tiny wrapper around a registry and an entity.
-*
-* @tparam Entity A valid entity type (see entt_traits for more details).
-*/
+ * @brief Non-owning handle to an entity.
+ *
+ * Tiny wrapper around a registry and an entity.
+ *
+ * @tparam Entity A valid entity type (see entt_traits for more details).
+ */
 template<typename Entity>
 struct basic_handle {
-    /*! @brief Underlying entity identifier. */
+    / *! @brief Underlying entity identifier.  */
     using entity_type = std::remove_const_t<Entity>;
 
-    /*! @brief Type of registry accepted by the handle. */
+    / *! @brief Type of registry accepted by the handle.  */
     using registry_type = std::conditional_t<
         std::is_const_v<Entity>,
         const basic_registry<entity_type>,
@@ -28,261 +28,261 @@ struct basic_handle {
     >;
 
     /**
-    * @brief Constructs a default invalid handle.
-    */
+     * @brief Constructs a default invalid handle.
+     */
     basic_handle() ENTT_NOEXCEPT
         : reg{nullptr}, entt{null}
     {}
 
     /**
-    * @brief Constructs a handle from a given registry and entity.
-    * @param ref An instance of the registry class.
-    * @param value An entity identifier.
-    */
+     * @brief Constructs a handle from a given registry and entity.
+     * @param ref An instance of the registry class.
+     * @param value An entity identifier.
+     */
     basic_handle(registry_type &ref, entity_type value) ENTT_NOEXCEPT
         : reg{&ref}, entt{value}
     {}
 
     /**
-    * @brief Compares two handles.
-    * @return True if both handles refer to the same registry and the same entity, false otherwise.
-    */
+     * @brief Compares two handles.
+     * @return True if both handles refer to the same registry and the same entity, false otherwise.
+     */
     bool operator==(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
         return reg == other.registry() && entt == other.entity();
     }
 
     /**
-    * @brief Compares two handles.
-    * @return False if both handles refer to the same registry and the same entity, true otherwise.
-    */
+     * @brief Compares two handles.
+     * @return False if both handles refer to the same registry and the same entity, true otherwise.
+     */
     bool operator!=(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
-        return !(*this == other);
+        return !( *this == other);
     }
 
     /**
-    * @brief Constructs a const handle from a non-const one.
-    * @return A const handle referring to the same entity.
-    */
+     * @brief Constructs a const handle from a non-const one.
+     * @return A const handle referring to the same entity.
+     */
     [[nodiscard]] operator basic_handle<const entity_type>() const ENTT_NOEXCEPT {
-        return reg ? basic_handle<const entity_type>{*reg, entt} : basic_handle<const entity_type>{};
+        return reg ? basic_handle<const entity_type>{ *reg, entt} : basic_handle<const entity_type>{};
     }
 
     /**
-    * @brief Converts a handle to its underlying entity.
-    * @return An entity identifier.
-    */
+     * @brief Converts a handle to its underlying entity.
+     * @return An entity identifier.
+     */
     [[nodiscard]] operator entity_type() const ENTT_NOEXCEPT {
         return entity();
     }
 
     /**
-    * @brief Checks if a handle refers to non-null registry pointer and entity.
-    * @return True if the handle refers to non-null registry and entity, false otherwise.
-    */
+     * @brief Checks if a handle refers to non-null registry pointer and entity.
+     * @return True if the handle refers to non-null registry and entity, false otherwise.
+     */
     [[nodiscard]] explicit operator bool() const {
         return reg && entt != null;
     }
 
     /**
-    * @brief Checks if a handle refers to a valid entity or not.
-    * @return True if the handle refers to a valid entity, false otherwise.
-    */
+     * @brief Checks if a handle refers to a valid entity or not.
+     * @return True if the handle refers to a valid entity, false otherwise.
+     */
     [[nodiscard]] bool valid() const {
         return reg->valid(entt);
     }
 
     /**
-    * @brief Returns a pointer to the underlying registry.
-    * @return A pointer to the underlying registry.
-    */
-    [[nodiscard]] registry_type * registry() const ENTT_NOEXCEPT {
+     * @brief Returns a pointer to the underlying registry.
+     * @return A pointer to the underlying registry.
+     */
+    [[nodiscard]] registry_type  * registry() const ENTT_NOEXCEPT {
         return reg;
     }
 
     /**
-    * @brief Returns the entity associated with a handle.
-    * @param value he entity associated with the handle.
-    */
+     * @brief Returns the entity associated with a handle.
+     * @param value he entity associated with the handle.
+     */
     [[nodiscard]] entity_type entity() const ENTT_NOEXCEPT {
         return entt;
     }
 
     /**
-    * @brief Assigns the given component to a handle.
-    * @sa basic_registry::emplace
-    * @tparam Component Type of component to create.
-    * @tparam Args Types of arguments to use to construct the component.
-    * @param args Parameters to use to initialize the component.
-    * @return A reference to the newly created component.
-    */
+     * @brief Assigns the given component to a handle.
+     * @sa basic_registry::emplace
+     * @tparam Component Type of component to create.
+     * @tparam Args Types of arguments to use to construct the component.
+     * @param args Parameters to use to initialize the component.
+     * @return A reference to the newly created component.
+     */
     template<typename Component, typename... Args>
     decltype(auto) emplace(Args &&... args) const {
         return reg->template emplace<Component>(entt, std::forward<Args>(args)...);
     }
 
     /**
-    * @brief Assigns or replaces the given component for a handle.
-    * @sa basic_registry::emplace_or_replace
-    * @tparam Component Type of component to assign or replace.
-    * @tparam Args Types of arguments to use to construct the component.
-    * @param args Parameters to use to initialize the component.
-    * @return A reference to the newly created component.
-    */
+     * @brief Assigns or replaces the given component for a handle.
+     * @sa basic_registry::emplace_or_replace
+     * @tparam Component Type of component to assign or replace.
+     * @tparam Args Types of arguments to use to construct the component.
+     * @param args Parameters to use to initialize the component.
+     * @return A reference to the newly created component.
+     */
     template<typename Component, typename... Args>
     decltype(auto) emplace_or_replace(Args &&... args) const {
         return reg->template emplace_or_replace<Component>(entt, std::forward<Args>(args)...);
     }
 
     /**
-    * @brief Patches the given component for a handle.
-    * @sa basic_registry::patch
-    * @tparam Component Type of component to patch.
-    * @tparam Func Types of the function objects to invoke.
-    * @param func Valid function objects.
-    * @return A reference to the patched component.
-    */
+     * @brief Patches the given component for a handle.
+     * @sa basic_registry::patch
+     * @tparam Component Type of component to patch.
+     * @tparam Func Types of the function objects to invoke.
+     * @param func Valid function objects.
+     * @return A reference to the patched component.
+     */
     template<typename Component, typename... Func>
     decltype(auto) patch(Func &&... func) const {
         return reg->template patch<Component>(entt, std::forward<Func>(func)...);
     }
 
     /**
-    * @brief Replaces the given component for a handle.
-    * @sa basic_registry::replace
-    * @tparam Component Type of component to replace.
-    * @tparam Args Types of arguments to use to construct the component.
-    * @param args Parameters to use to initialize the component.
-    * @return A reference to the component being replaced.
-    */
+     * @brief Replaces the given component for a handle.
+     * @sa basic_registry::replace
+     * @tparam Component Type of component to replace.
+     * @tparam Args Types of arguments to use to construct the component.
+     * @param args Parameters to use to initialize the component.
+     * @return A reference to the component being replaced.
+     */
     template<typename Component, typename... Args>
     decltype(auto) replace(Args &&... args) const {
         return reg->template replace<Component>(entt, std::forward<Args>(args)...);
     }
 
     /**
-    * @brief Removes the given components from a handle.
-    * @sa basic_registry::remove
-    * @tparam Component Types of components to remove.
-    */
+     * @brief Removes the given components from a handle.
+     * @sa basic_registry::remove
+     * @tparam Component Types of components to remove.
+     */
     template<typename... Components>
     void remove() const {
         reg->template remove<Components...>(entt);
     }
 
     /**
-    * @brief Removes the given components from a handle.
-    * @sa basic_registry::remove_if_exists
-    * @tparam Component Types of components to remove.
-    * @return The number of components actually removed.
-    */
+     * @brief Removes the given components from a handle.
+     * @sa basic_registry::remove_if_exists
+     * @tparam Component Types of components to remove.
+     * @return The number of components actually removed.
+     */
     template<typename... Components>
     decltype(auto) remove_if_exists() const {
         return reg->template remove_if_exists<Components...>(entt);
     }
 
     /**
-    * @brief Removes all the components from a handle and makes it orphaned.
-    * @sa basic_registry::remove_all
-    */
+     * @brief Removes all the components from a handle and makes it orphaned.
+     * @sa basic_registry::remove_all
+     */
     void remove_all() const {
         reg->remove_all(entt);
     }
 
     /**
-    * @brief Checks if a handle has all the given components.
-    * @sa basic_registry::has
-    * @tparam Component Components for which to perform the check.
-    * @return True if the handle has all the components, false otherwise.
-    */
+     * @brief Checks if a handle has all the given components.
+     * @sa basic_registry::has
+     * @tparam Component Components for which to perform the check.
+     * @return True if the handle has all the components, false otherwise.
+     */
     template<typename... Components>
     [[nodiscard]] decltype(auto) has() const {
         return reg->template has<Components...>(entt);
     }
 
     /**
-    * @brief Checks if a handle has at least one of the given components.
-    * @sa basic_registry::any
-    * @tparam Component Components for which to perform the check.
-    * @return True if the handle has at least one of the given components,
-    * false otherwise.
-    */
+     * @brief Checks if a handle has at least one of the given components.
+     * @sa basic_registry::any
+     * @tparam Component Components for which to perform the check.
+     * @return True if the handle has at least one of the given components,
+     * false otherwise.
+     */
     template<typename... Components>
     [[nodiscard]] decltype(auto) any() const {
         return reg->template any<Components...>(entt);
     }
 
     /**
-    * @brief Returns references to the given components for a handle.
-    * @sa basic_registry::get
-    * @tparam Component Types of components to get.
-    * @return References to the components owned by the handle.
-    */
+     * @brief Returns references to the given components for a handle.
+     * @sa basic_registry::get
+     * @tparam Component Types of components to get.
+     * @return References to the components owned by the handle.
+     */
     template<typename... Components>
     [[nodiscard]] decltype(auto) get() const {
         return reg->template get<Components...>(entt);
     }
 
     /**
-    * @brief Returns a reference to the given component for a handle.
-    * @sa basic_registry::get_or_emplace
-    * @tparam Component Type of component to get.
-    * @tparam Args Types of arguments to use to construct the component.
-    * @param args Parameters to use to initialize the component.
-    * @return Reference to the component owned by the handle.
-    */
+     * @brief Returns a reference to the given component for a handle.
+     * @sa basic_registry::get_or_emplace
+     * @tparam Component Type of component to get.
+     * @tparam Args Types of arguments to use to construct the component.
+     * @param args Parameters to use to initialize the component.
+     * @return Reference to the component owned by the handle.
+     */
     template<typename Component, typename... Args>
     [[nodiscard]] decltype(auto) get_or_emplace(Args &&... args) const {
         return reg->template get_or_emplace<Component>(entt, std::forward<Args>(args)...);
     }
 
     /**
-    * @brief Returns pointers to the given components for a handle.
-    * @sa basic_registry::try_get
-    * @tparam Component Types of components to get.
-    * @return Pointers to the components owned by the handle.
-    */
+     * @brief Returns pointers to the given components for a handle.
+     * @sa basic_registry::try_get
+     * @tparam Component Types of components to get.
+     * @return Pointers to the components owned by the handle.
+     */
     template<typename... Components>
     [[nodiscard]] decltype(auto) try_get() const {
         return reg->template try_get<Components...>(entt);
     }
 
     /**
-    * @brief Checks if a handle has components assigned.
-    * @return True if the handle has no components assigned, false otherwise.
-    */
+     * @brief Checks if a handle has components assigned.
+     * @return True if the handle has no components assigned, false otherwise.
+     */
     [[nodiscard]] bool orphan() const {
         return reg->orphan(entt);
     }
 
     /**
-    * @brief Visits a handle and returns the types for its components.
-    * @sa basic_registry::visit
-    * @tparam Func Type of the function object to invoke.
-    * @param func A valid function object.
-    */
+     * @brief Visits a handle and returns the types for its components.
+     * @sa basic_registry::visit
+     * @tparam Func Type of the function object to invoke.
+     * @param func A valid function object.
+     */
     template<typename Func>
     void visit(Func &&func) const {
         reg->visit(entt, std::forward<Func>(func));
     }
 
 private:
-    registry_type *reg;
+    registry_type  *reg;
     entity_type entt;
 };
 
 
 /**
-* @brief Deduction guide.
-* @tparam Entity A valid entity type (see entt_traits for more details).
-*/
+ * @brief Deduction guide.
+ * @tparam Entity A valid entity type (see entt_traits for more details).
+ */
 template<typename Entity>
 basic_handle(basic_registry<Entity> &, Entity) -> basic_handle<Entity>;
 
 
 /**
-* @brief Deduction guide.
-* @tparam Entity A valid entity type (see entt_traits for more details).
-*/
+ * @brief Deduction guide.
+ * @tparam Entity A valid entity type (see entt_traits for more details).
+ */
 template<typename Entity>
 basic_handle(const basic_registry<Entity> &, Entity) -> basic_handle<const Entity>;
 

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -17,10 +17,10 @@ namespace entt {
  */
 template<typename Entity>
 struct basic_handle {
-    / *! @brief Underlying entity identifier.  */
+    /*! @brief Underlying entity identifier. */
     using entity_type = std::remove_const_t<Entity>;
 
-    / *! @brief Type of registry accepted by the handle.  */
+    /*! @brief Type of registry accepted by the handle. */
     using registry_type = std::conditional_t<
         std::is_const_v<Entity>,
         const basic_registry<entity_type>,

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -8,345 +8,345 @@
 namespace entt {
 
 
-/**
- * @brief Non-owning handle to an entity.
- *
- * Tiny wrapper around a registry and an entity.
- *
- * @tparam Entity A valid entity type (see entt_traits for more details).
- */
-template<typename Entity>
-struct basic_handle {
-    /*! @brief Underlying entity identifier. */
-    using entity_type = std::remove_const_t<Entity>;
-
-    /*! @brief Type of registry accepted by the handle. */
-    using registry_type = std::conditional_t<
-        std::is_const_v<Entity>,
-        const basic_registry<entity_type>,
-        basic_registry<entity_type>
-    >;
-
     /**
-    * @brief Constructs a default invalid handle.
+    * @brief Non-owning handle to an entity.
+    *
+    * Tiny wrapper around a registry and an entity.
+    *
+    * @tparam Entity A valid entity type (see entt_traits for more details).
     */
-    basic_handle() ENTT_NOEXCEPT
-        : basic_handle{null}
-    {}
+    template<typename Entity>
+    struct basic_handle {
+        /*! @brief Underlying entity identifier. */
+        using entity_type = std::remove_const_t<Entity>;
+
+        /*! @brief Type of registry accepted by the handle. */
+        using registry_type = std::conditional_t<
+            std::is_const_v<Entity>,
+            const basic_registry<entity_type>,
+            basic_registry<entity_type>
+        >;
+
+        /**
+        * @brief Constructs a default invalid handle.
+        */
+        basic_handle() ENTT_NOEXCEPT
+            : reg{nullptr}, entt{null}
+        {}
+
+        /**
+        * @brief Constructs a handle from another handle.
+        * @param other Another handle
+        */
+        //basic_handle(const basic_handle &other) ENTT_NOEXCEPT = default;
+
+        /**
+        * @brief Constructs a handle from a given registry and entity.
+        * @param ref An instance of the registry class.
+        * @param value An entity identifier.
+        */
+        basic_handle(registry_type &ref, entity_type value = null) ENTT_NOEXCEPT
+            : reg{&ref}, entt{value}
+        {}
+
+        /**
+        * @brief Assigns an entity to a handle while leaving registry unchanged.
+        * @param value An entity identifier.
+        * @return This handle.
+        */
+        basic_handle & operator=(const entity_type value) ENTT_NOEXCEPT {
+            entt = value;
+            return *this;
+        }
+
+        /**
+        * @brief Assigns a registry and an entity to a handle.
+        * @param other Another handle.
+        * @return This handle.
+        */
+        //basic_handle & operator=(const basic_handle &other) ENTT_NOEXCEPT = default;
+
+        /**
+        * @brief Compares two handles.
+        * @return True if both handles refer to the same registry and the same entity, false otherwise.
+        */
+        bool operator==(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
+            return reg == other.registry() && entt == other.entity();
+        }
+
+        /**
+        * @brief Compares two handles.
+        * @return True if both handles refer to the same registry and the same entity, false otherwise.
+        */
+        bool operator==(const basic_handle<const entity_type> &other) const ENTT_NOEXCEPT {
+            return reg == other.registry() && entt == other.entity();
+        }
+
+        /**
+        * @brief Compares two handles.
+        * @return False if both handles refer to the same registry and the same entity, true otherwise.
+        */
+        bool operator!=(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
+            return !(*this == other);
+        }
+
+        /**
+        * @brief Compares two handles.
+        * @return False if both handles refer to the same registry and the same entity, true otherwise.
+        */
+        bool operator!=(const basic_handle<const entity_type> &other) const ENTT_NOEXCEPT {
+            return !(*this == other);
+        }
+
+        /**
+        * @brief Constructs a const handle from a non-const one.
+        * @return A const handle referring to the same entity.
+        */
+        [[nodiscard]] operator basic_handle<const entity_type>() const ENTT_NOEXCEPT {
+            return reg ? basic_handle<const entity_type>{*reg, entt} : basic_handle<const entity_type>{};
+        }
+
+        /**
+        * @brief Converts a handle to its underlying entity.
+        * @return An entity identifier.
+        */
+        [[nodiscard]] operator entity_type() const ENTT_NOEXCEPT {
+            return entity();
+        }
+
+        /**
+        * @brief Checks if a handle refers to non-null registry pointer and entity.
+        * @return True if the handle refers to non-null registry and entity, false otherwise.
+        */
+        [[nodiscard]] explicit operator bool() const {
+            return reg && entt != null;
+        }
+
+        /**
+        * @brief Checks if a handle refers to a valid entity or not.
+        * @return True if the handle refers to a valid entity, false otherwise.
+        */
+        [[nodiscard]] bool valid() const {
+            return reg->valid(entt);
+        }
+
+        /**
+        * @brief Returns a pointer to the underlying registry.
+        * @return A pointer to the underlying registry.
+        */
+        [[nodiscard]] registry_type * registry() const ENTT_NOEXCEPT {
+            return reg;
+        }
+
+        /**
+        * @brief Sets a new pointer to the underlying registry.
+        * @param value a pointer to the new underlying registry.
+        */
+        void registry(registry_type * value) ENTT_NOEXCEPT {
+            reg = value
+        }
+
+        /**
+        * @brief Returns the entity associated with a handle.
+        * @param value he entity associated with the handle.
+        */
+        [[nodiscard]] entity_type entity() const ENTT_NOEXCEPT {
+            return entt;
+        }
+
+        /**
+        * @brief Sets a new entity associated with a handle.
+        * @param value the new entity associated with the handle.
+        */
+        void entity(entity_type value) ENTT_NOEXCEPT {
+            entt = value;
+        }
+
+        /**
+        * @brief Clears the entity associated with a handle.
+        */
+        void entity(null_t) ENTT_NOEXCEPT {
+            entt = static_cast<entity_type>(static_cast<typename entt_traits<entity_type>::entity_type>(null));
+        }
+
+        /**
+        * @brief Assigns the given component to a handle.
+        * @sa basic_registry::emplace
+        * @tparam Component Type of component to create.
+        * @tparam Args Types of arguments to use to construct the component.
+        * @param args Parameters to use to initialize the component.
+        * @return A reference to the newly created component.
+        */
+        template<typename Component, typename... Args>
+        decltype(auto) emplace(Args &&... args) const {
+            return reg->template emplace<Component>(entt, std::forward<Args>(args)...);
+        }
+
+        /**
+        * @brief Assigns or replaces the given component for a handle.
+        * @sa basic_registry::emplace_or_replace
+        * @tparam Component Type of component to assign or replace.
+        * @tparam Args Types of arguments to use to construct the component.
+        * @param args Parameters to use to initialize the component.
+        * @return A reference to the newly created component.
+        */
+        template<typename Component, typename... Args>
+        decltype(auto) emplace_or_replace(Args &&... args) const {
+            return reg->template emplace_or_replace<Component>(entt, std::forward<Args>(args)...);
+        }
+
+        /**
+        * @brief Patches the given component for a handle.
+        * @sa basic_registry::patch
+        * @tparam Component Type of component to patch.
+        * @tparam Func Types of the function objects to invoke.
+        * @param func Valid function objects.
+        * @return A reference to the patched component.
+        */
+        template<typename Component, typename... Func>
+        decltype(auto) patch(Func &&... func) const {
+            return reg->template patch<Component>(entt, std::forward<Func>(func)...);
+        }
+
+        /**
+        * @brief Replaces the given component for a handle.
+        * @sa basic_registry::replace
+        * @tparam Component Type of component to replace.
+        * @tparam Args Types of arguments to use to construct the component.
+        * @param args Parameters to use to initialize the component.
+        * @return A reference to the component being replaced.
+        */
+        template<typename Component, typename... Args>
+        decltype(auto) replace(Args &&... args) const {
+            return reg->template replace<Component>(entt, std::forward<Args>(args)...);
+        }
+
+        /**
+        * @brief Removes the given components from a handle.
+        * @sa basic_registry::remove
+        * @tparam Component Types of components to remove.
+        */
+        template<typename... Components>
+        void remove() const {
+            reg->template remove<Components...>(entt);
+        }
+
+        /**
+        * @brief Removes the given components from a handle.
+        * @sa basic_registry::remove_if_exists
+        * @tparam Component Types of components to remove.
+        * @return The number of components actually removed.
+        */
+        template<typename... Components>
+        decltype(auto) remove_if_exists() const {
+            return reg->template remove_if_exists<Components...>(entt);
+        }
+
+        /**
+        * @brief Removes all the components from a handle and makes it orphaned.
+        * @sa basic_registry::remove_all
+        */
+        void remove_all() const {
+            reg->remove_all(entt);
+        }
+
+        /**
+        * @brief Checks if a handle has all the given components.
+        * @sa basic_registry::has
+        * @tparam Component Components for which to perform the check.
+        * @return True if the handle has all the components, false otherwise.
+        */
+        template<typename... Components>
+        [[nodiscard]] decltype(auto) has() const {
+            return reg->template has<Components...>(entt);
+        }
+
+        /**
+        * @brief Checks if a handle has at least one of the given components.
+        * @sa basic_registry::any
+        * @tparam Component Components for which to perform the check.
+        * @return True if the handle has at least one of the given components,
+        * false otherwise.
+        */
+        template<typename... Components>
+        [[nodiscard]] decltype(auto) any() const {
+            return reg->template any<Components...>(entt);
+        }
+
+        /**
+        * @brief Returns references to the given components for a handle.
+        * @sa basic_registry::get
+        * @tparam Component Types of components to get.
+        * @return References to the components owned by the handle.
+        */
+        template<typename... Components>
+        [[nodiscard]] decltype(auto) get() const {
+            return reg->template get<Components...>(entt);
+        }
+
+        /**
+        * @brief Returns a reference to the given component for a handle.
+        * @sa basic_registry::get_or_emplace
+        * @tparam Component Type of component to get.
+        * @tparam Args Types of arguments to use to construct the component.
+        * @param args Parameters to use to initialize the component.
+        * @return Reference to the component owned by the handle.
+        */
+        template<typename Component, typename... Args>
+        [[nodiscard]] decltype(auto) get_or_emplace(Args &&... args) const {
+            return reg->template get_or_emplace<Component>(entt, std::forward<Args>(args)...);
+        }
+
+        /**
+        * @brief Returns pointers to the given components for a handle.
+        * @sa basic_registry::try_get
+        * @tparam Component Types of components to get.
+        * @return Pointers to the components owned by the handle.
+        */
+        template<typename... Components>
+        [[nodiscard]] decltype(auto) try_get() const {
+            return reg->template try_get<Components...>(entt);
+        }
+
+        /**
+        * @brief Checks if a handle has components assigned.
+        * @return True if the handle has no components assigned, false otherwise.
+        */
+        [[nodiscard]] bool orphan() const {
+            return reg->orphan(entt);
+        }
+
+        /**
+        * @brief Visits a handle and returns the types for its components.
+        * @sa basic_registry::visit
+        * @tparam Func Type of the function object to invoke.
+        * @param func A valid function object.
+        */
+        template<typename Func>
+        void visit(Func &&func) const {
+            reg->visit(entt, std::forward<Func>(func));
+        }
+
+    private:
+        registry_type *reg;
+        entity_type entt;
+    };
+
 
     /**
-    * @brief Constructs an invalid handle.
+    * @brief Deduction guide.
+    * @tparam Entity A valid entity type (see entt_traits for more details).
     */
-    basic_handle(null_t) ENTT_NOEXCEPT
-        : basic_handle{nullptr, null}
-    {}
+    template<typename Entity>
+    basic_handle(basic_registry<Entity> &, Entity) -> basic_handle<Entity>;
+
 
     /**
-    * @brief Constructs a handle from another handle.
-    * @param other Another handle
+    * @brief Deduction guide.
+    * @tparam Entity A valid entity type (see entt_traits for more details).
     */
-    basic_handle(const basic_handle &other) ENTT_NOEXCEPT
-        : basic_handle{other.reg, other.entt}
-    {}
-
-    /**
-     * @brief Constructs a handle from a given registry and entity.
-     * @param ref An instance of the registry class.
-     * @param value An entity identifier.
-     */
-    basic_handle(registry_type *registry, entity_type value = null) ENTT_NOEXCEPT
-        : reg{registry}, entt{value}
-    {}
-
-    /**
-     * @brief Assigns an entity to a handle while leaving registry unchanged.
-     * @param value An entity identifier.
-     * @return This handle.
-     */
-    basic_handle & operator=(const entity_type value) ENTT_NOEXCEPT {
-        entt = value;
-        return *this;
-    }
-
-    /**
-    * @brief Assigns a registry and an entity to a handle.
-    * @param other Another handle.
-    * @return This handle.
-    */
-    basic_handle & operator=(const basic_handle &other) ENTT_NOEXCEPT {
-        reg = other.reg;
-        entt = other.entt;
-        return *this;
-    }
-
-    /**
-     * @brief Assigns the null object to a handle, invalidating both registry and entity.
-     * @return This handle.
-     */
-    basic_handle & operator=(null_t) ENTT_NOEXCEPT {
-        reg = nullptr;
-        entt = null;
-        return *this;
-    }
-
-    /**
-    * @brief Compares two handles.
-    * @return True if both handles refer to the same registry and the same entity, false otherwise.
-    */
-    bool operator==(const basic_handle &other) const ENTT_NOEXCEPT {
-        return reg == other.reg && entt == other.entt;
-    }
-
-    /**
-    * @brief Compares two handles.
-    * @return False if both handles refer to the same registry and the same entity, true otherwise.
-    */
-    bool operator!=(const basic_handle &other) const ENTT_NOEXCEPT {
-        return !(*this == other);
-    }
-
-    /**
-    * @brief Compares a handle to the null object.
-    * @return True if the handle refers to null registry and null entity, false otherwise.
-    */
-    bool operator==(null_t) const ENTT_NOEXCEPT {
-        return !reg || entt == null;
-    }
-
-    /**
-    * @brief Compares a handle to the null object.
-    * @return False if the handle refers to null registry and null entity, true otherwise.
-    */
-    bool operator!=(null_t) const ENTT_NOEXCEPT {
-        return !(*this == null);
-    }
-
-    /**
-     * @brief Constructs a const handle from a non-const one.
-     * @return A const handle referring to the same entity.
-     */
-    [[nodiscard]] operator basic_handle<const entity_type>() const ENTT_NOEXCEPT {
-        return {reg, entt};
-    }
-
-    /**
-     * @brief Converts a handle to its underlying entity.
-     * @return An entity identifier.
-     */
-    [[nodiscard]] operator entity_type() const ENTT_NOEXCEPT {
-        return entity();
-    }
-
-    /**
-    * @brief Checks if a handle refers to non-null registry pointer and entity.
-    * @return True if the handle refers to non-null registry and entity, false otherwise.
-    */
-    [[nodiscard]] explicit operator bool() const {
-        return (*this != null);
-    }
-
-    /**
-    * @brief Checks if a handle refers to a valid entity or not.
-    * @return True if the handle refers to a valid entity, false otherwise.
-    */
-    [[nodiscard]] bool valid() const {
-        return reg->valid(entt);
-    }
-
-    /**
-     * @brief Returns a reference to the underlying registry.
-     * @return A reference to the underlying registry.
-     */
-    [[nodiscard]] registry_type * registry() const ENTT_NOEXCEPT {
-        return reg;
-    }
-
-    /**
-     * @brief Returns the entity associated with a handle.
-     * @return The entity associated with the handle.
-     */
-    [[nodiscard]] entity_type entity() const ENTT_NOEXCEPT {
-        return entt;
-    }
-
-    /**
-     * @brief Assigns the given component to a handle.
-     * @sa basic_registry::emplace
-     * @tparam Component Type of component to create.
-     * @tparam Args Types of arguments to use to construct the component.
-     * @param args Parameters to use to initialize the component.
-     * @return A reference to the newly created component.
-     */
-    template<typename Component, typename... Args>
-    decltype(auto) emplace(Args &&... args) const {
-        return reg->template emplace<Component>(entt, std::forward<Args>(args)...);
-    }
-
-    /**
-     * @brief Assigns or replaces the given component for a handle.
-     * @sa basic_registry::emplace_or_replace
-     * @tparam Component Type of component to assign or replace.
-     * @tparam Args Types of arguments to use to construct the component.
-     * @param args Parameters to use to initialize the component.
-     * @return A reference to the newly created component.
-     */
-    template<typename Component, typename... Args>
-    decltype(auto) emplace_or_replace(Args &&... args) const {
-        return reg->template emplace_or_replace<Component>(entt, std::forward<Args>(args)...);
-    }
-
-    /**
-     * @brief Patches the given component for a handle.
-     * @sa basic_registry::patch
-     * @tparam Component Type of component to patch.
-     * @tparam Func Types of the function objects to invoke.
-     * @param func Valid function objects.
-     * @return A reference to the patched component.
-     */
-    template<typename Component, typename... Func>
-    decltype(auto) patch(Func &&... func) const {
-        return reg->template patch<Component>(entt, std::forward<Func>(func)...);
-    }
-
-    /**
-     * @brief Replaces the given component for a handle.
-     * @sa basic_registry::replace
-     * @tparam Component Type of component to replace.
-     * @tparam Args Types of arguments to use to construct the component.
-     * @param args Parameters to use to initialize the component.
-     * @return A reference to the component being replaced.
-     */
-    template<typename Component, typename... Args>
-    decltype(auto) replace(Args &&... args) const {
-        return reg->template replace<Component>(entt, std::forward<Args>(args)...);
-    }
-
-    /**
-     * @brief Removes the given components from a handle.
-     * @sa basic_registry::remove
-     * @tparam Component Types of components to remove.
-     */
-    template<typename... Components>
-    void remove() const {
-        reg->template remove<Components...>(entt);
-    }
-
-    /**
-     * @brief Removes the given components from a handle.
-     * @sa basic_registry::remove_if_exists
-     * @tparam Component Types of components to remove.
-     * @return The number of components actually removed.
-     */
-    template<typename... Components>
-    decltype(auto) remove_if_exists() const {
-        return reg->template remove_if_exists<Components...>(entt);
-    }
-
-    /**
-     * @brief Removes all the components from a handle and makes it orphaned.
-     * @sa basic_registry::remove_all
-     */
-    void remove_all() const {
-        reg->remove_all(entt);
-    }
-
-    /**
-     * @brief Checks if a handle has all the given components.
-     * @sa basic_registry::has
-     * @tparam Component Components for which to perform the check.
-     * @return True if the handle has all the components, false otherwise.
-     */
-    template<typename... Components>
-    [[nodiscard]] decltype(auto) has() const {
-        return reg->template has<Components...>(entt);
-    }
-
-    /**
-     * @brief Checks if a handle has at least one of the given components.
-     * @sa basic_registry::any
-     * @tparam Component Components for which to perform the check.
-     * @return True if the handle has at least one of the given components,
-     * false otherwise.
-     */
-    template<typename... Components>
-    [[nodiscard]] decltype(auto) any() const {
-        return reg->template any<Components...>(entt);
-    }
-
-    /**
-     * @brief Returns references to the given components for a handle.
-     * @sa basic_registry::get
-     * @tparam Component Types of components to get.
-     * @return References to the components owned by the handle.
-     */
-    template<typename... Components>
-    [[nodiscard]] decltype(auto) get() const {
-        return reg->template get<Components...>(entt);
-    }
-
-    /**
-     * @brief Returns a reference to the given component for a handle.
-     * @sa basic_registry::get_or_emplace
-     * @tparam Component Type of component to get.
-     * @tparam Args Types of arguments to use to construct the component.
-     * @param args Parameters to use to initialize the component.
-     * @return Reference to the component owned by the handle.
-     */
-    template<typename Component, typename... Args>
-    [[nodiscard]] decltype(auto) get_or_emplace(Args &&... args) const {
-        return reg->template get_or_emplace<Component>(entt, std::forward<Args>(args)...);
-    }
-
-    /**
-     * @brief Returns pointers to the given components for a handle.
-     * @sa basic_registry::try_get
-     * @tparam Component Types of components to get.
-     * @return Pointers to the components owned by the handle.
-     */
-    template<typename... Components>
-    [[nodiscard]] decltype(auto) try_get() const {
-        return reg->template try_get<Components...>(entt);
-    }
-
-    /**
-     * @brief Checks if a handle has components assigned.
-     * @return True if the handle has no components assigned, false otherwise.
-     */
-    [[nodiscard]] bool orphan() const {
-        return reg->orphan(entt);
-    }
-
-    /**
-     * @brief Visits a handle and returns the types for its components.
-     * @sa basic_registry::visit
-     * @tparam Func Type of the function object to invoke.
-     * @param func A valid function object.
-     */
-    template<typename Func>
-    void visit(Func &&func) const {
-        reg->visit(entt, std::forward<Func>(func));
-    }
-
-private:
-    registry_type *reg;
-    entity_type entt;
-};
-
-
-/**
- * @brief Deduction guide.
- * @tparam Entity A valid entity type (see entt_traits for more details).
- */
-template<typename Entity>
-basic_handle(basic_registry<Entity> *, Entity) -> basic_handle<Entity>;
-
-
-/**
- * @brief Deduction guide.
- * @tparam Entity A valid entity type (see entt_traits for more details).
- */
-template<typename Entity>
-basic_handle(const basic_registry<Entity> *, Entity) -> basic_handle<const Entity>;
+    template<typename Entity>
+    basic_handle(const basic_registry<Entity> &, Entity) -> basic_handle<const Entity>;
 
 
 }

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -143,7 +143,7 @@ namespace entt {
         * @param value a pointer to the new underlying registry.
         */
         void registry(registry_type * value) ENTT_NOEXCEPT {
-            reg = value
+            reg = value;
         }
 
         /**

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -110,7 +110,7 @@ struct basic_handle {
     * @return True if the handle refers to null registry and null entity, false otherwise.
     */
     bool operator==(null_t) const ENTT_NOEXCEPT {
-        return reg && entt != null;
+        return !reg || entt == null;
     }
 
     /**

--- a/src/entt/entity/handle.hpp
+++ b/src/entt/entity/handle.hpp
@@ -8,345 +8,283 @@
 namespace entt {
 
 
-    /**
-    * @brief Non-owning handle to an entity.
-    *
-    * Tiny wrapper around a registry and an entity.
-    *
-    * @tparam Entity A valid entity type (see entt_traits for more details).
-    */
-    template<typename Entity>
-    struct basic_handle {
-        /*! @brief Underlying entity identifier. */
-        using entity_type = std::remove_const_t<Entity>;
+/**
+* @brief Non-owning handle to an entity.
+*
+* Tiny wrapper around a registry and an entity.
+*
+* @tparam Entity A valid entity type (see entt_traits for more details).
+*/
+template<typename Entity>
+struct basic_handle {
+    /*! @brief Underlying entity identifier. */
+    using entity_type = std::remove_const_t<Entity>;
 
-        /*! @brief Type of registry accepted by the handle. */
-        using registry_type = std::conditional_t<
-            std::is_const_v<Entity>,
-            const basic_registry<entity_type>,
-            basic_registry<entity_type>
-        >;
-
-        /**
-        * @brief Constructs a default invalid handle.
-        */
-        basic_handle() ENTT_NOEXCEPT
-            : reg{nullptr}, entt{null}
-        {}
-
-        /**
-        * @brief Constructs a handle from another handle.
-        * @param other Another handle
-        */
-        //basic_handle(const basic_handle &other) ENTT_NOEXCEPT = default;
-
-        /**
-        * @brief Constructs a handle from a given registry and entity.
-        * @param ref An instance of the registry class.
-        * @param value An entity identifier.
-        */
-        basic_handle(registry_type &ref, entity_type value = null) ENTT_NOEXCEPT
-            : reg{&ref}, entt{value}
-        {}
-
-        /**
-        * @brief Assigns an entity to a handle while leaving registry unchanged.
-        * @param value An entity identifier.
-        * @return This handle.
-        */
-        basic_handle & operator=(const entity_type value) ENTT_NOEXCEPT {
-            entt = value;
-            return *this;
-        }
-
-        /**
-        * @brief Assigns a registry and an entity to a handle.
-        * @param other Another handle.
-        * @return This handle.
-        */
-        //basic_handle & operator=(const basic_handle &other) ENTT_NOEXCEPT = default;
-
-        /**
-        * @brief Compares two handles.
-        * @return True if both handles refer to the same registry and the same entity, false otherwise.
-        */
-        bool operator==(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
-            return reg == other.registry() && entt == other.entity();
-        }
-
-        /**
-        * @brief Compares two handles.
-        * @return True if both handles refer to the same registry and the same entity, false otherwise.
-        */
-        bool operator==(const basic_handle<const entity_type> &other) const ENTT_NOEXCEPT {
-            return reg == other.registry() && entt == other.entity();
-        }
-
-        /**
-        * @brief Compares two handles.
-        * @return False if both handles refer to the same registry and the same entity, true otherwise.
-        */
-        bool operator!=(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
-            return !(*this == other);
-        }
-
-        /**
-        * @brief Compares two handles.
-        * @return False if both handles refer to the same registry and the same entity, true otherwise.
-        */
-        bool operator!=(const basic_handle<const entity_type> &other) const ENTT_NOEXCEPT {
-            return !(*this == other);
-        }
-
-        /**
-        * @brief Constructs a const handle from a non-const one.
-        * @return A const handle referring to the same entity.
-        */
-        [[nodiscard]] operator basic_handle<const entity_type>() const ENTT_NOEXCEPT {
-            return reg ? basic_handle<const entity_type>{*reg, entt} : basic_handle<const entity_type>{};
-        }
-
-        /**
-        * @brief Converts a handle to its underlying entity.
-        * @return An entity identifier.
-        */
-        [[nodiscard]] operator entity_type() const ENTT_NOEXCEPT {
-            return entity();
-        }
-
-        /**
-        * @brief Checks if a handle refers to non-null registry pointer and entity.
-        * @return True if the handle refers to non-null registry and entity, false otherwise.
-        */
-        [[nodiscard]] explicit operator bool() const {
-            return reg && entt != null;
-        }
-
-        /**
-        * @brief Checks if a handle refers to a valid entity or not.
-        * @return True if the handle refers to a valid entity, false otherwise.
-        */
-        [[nodiscard]] bool valid() const {
-            return reg->valid(entt);
-        }
-
-        /**
-        * @brief Returns a pointer to the underlying registry.
-        * @return A pointer to the underlying registry.
-        */
-        [[nodiscard]] registry_type * registry() const ENTT_NOEXCEPT {
-            return reg;
-        }
-
-        /**
-        * @brief Sets a new pointer to the underlying registry.
-        * @param value a pointer to the new underlying registry.
-        */
-        void registry(registry_type * value) ENTT_NOEXCEPT {
-            reg = value;
-        }
-
-        /**
-        * @brief Returns the entity associated with a handle.
-        * @param value he entity associated with the handle.
-        */
-        [[nodiscard]] entity_type entity() const ENTT_NOEXCEPT {
-            return entt;
-        }
-
-        /**
-        * @brief Sets a new entity associated with a handle.
-        * @param value the new entity associated with the handle.
-        */
-        void entity(entity_type value) ENTT_NOEXCEPT {
-            entt = value;
-        }
-
-        /**
-        * @brief Clears the entity associated with a handle.
-        */
-        void entity(null_t) ENTT_NOEXCEPT {
-            entt = static_cast<entity_type>(static_cast<typename entt_traits<entity_type>::entity_type>(null));
-        }
-
-        /**
-        * @brief Assigns the given component to a handle.
-        * @sa basic_registry::emplace
-        * @tparam Component Type of component to create.
-        * @tparam Args Types of arguments to use to construct the component.
-        * @param args Parameters to use to initialize the component.
-        * @return A reference to the newly created component.
-        */
-        template<typename Component, typename... Args>
-        decltype(auto) emplace(Args &&... args) const {
-            return reg->template emplace<Component>(entt, std::forward<Args>(args)...);
-        }
-
-        /**
-        * @brief Assigns or replaces the given component for a handle.
-        * @sa basic_registry::emplace_or_replace
-        * @tparam Component Type of component to assign or replace.
-        * @tparam Args Types of arguments to use to construct the component.
-        * @param args Parameters to use to initialize the component.
-        * @return A reference to the newly created component.
-        */
-        template<typename Component, typename... Args>
-        decltype(auto) emplace_or_replace(Args &&... args) const {
-            return reg->template emplace_or_replace<Component>(entt, std::forward<Args>(args)...);
-        }
-
-        /**
-        * @brief Patches the given component for a handle.
-        * @sa basic_registry::patch
-        * @tparam Component Type of component to patch.
-        * @tparam Func Types of the function objects to invoke.
-        * @param func Valid function objects.
-        * @return A reference to the patched component.
-        */
-        template<typename Component, typename... Func>
-        decltype(auto) patch(Func &&... func) const {
-            return reg->template patch<Component>(entt, std::forward<Func>(func)...);
-        }
-
-        /**
-        * @brief Replaces the given component for a handle.
-        * @sa basic_registry::replace
-        * @tparam Component Type of component to replace.
-        * @tparam Args Types of arguments to use to construct the component.
-        * @param args Parameters to use to initialize the component.
-        * @return A reference to the component being replaced.
-        */
-        template<typename Component, typename... Args>
-        decltype(auto) replace(Args &&... args) const {
-            return reg->template replace<Component>(entt, std::forward<Args>(args)...);
-        }
-
-        /**
-        * @brief Removes the given components from a handle.
-        * @sa basic_registry::remove
-        * @tparam Component Types of components to remove.
-        */
-        template<typename... Components>
-        void remove() const {
-            reg->template remove<Components...>(entt);
-        }
-
-        /**
-        * @brief Removes the given components from a handle.
-        * @sa basic_registry::remove_if_exists
-        * @tparam Component Types of components to remove.
-        * @return The number of components actually removed.
-        */
-        template<typename... Components>
-        decltype(auto) remove_if_exists() const {
-            return reg->template remove_if_exists<Components...>(entt);
-        }
-
-        /**
-        * @brief Removes all the components from a handle and makes it orphaned.
-        * @sa basic_registry::remove_all
-        */
-        void remove_all() const {
-            reg->remove_all(entt);
-        }
-
-        /**
-        * @brief Checks if a handle has all the given components.
-        * @sa basic_registry::has
-        * @tparam Component Components for which to perform the check.
-        * @return True if the handle has all the components, false otherwise.
-        */
-        template<typename... Components>
-        [[nodiscard]] decltype(auto) has() const {
-            return reg->template has<Components...>(entt);
-        }
-
-        /**
-        * @brief Checks if a handle has at least one of the given components.
-        * @sa basic_registry::any
-        * @tparam Component Components for which to perform the check.
-        * @return True if the handle has at least one of the given components,
-        * false otherwise.
-        */
-        template<typename... Components>
-        [[nodiscard]] decltype(auto) any() const {
-            return reg->template any<Components...>(entt);
-        }
-
-        /**
-        * @brief Returns references to the given components for a handle.
-        * @sa basic_registry::get
-        * @tparam Component Types of components to get.
-        * @return References to the components owned by the handle.
-        */
-        template<typename... Components>
-        [[nodiscard]] decltype(auto) get() const {
-            return reg->template get<Components...>(entt);
-        }
-
-        /**
-        * @brief Returns a reference to the given component for a handle.
-        * @sa basic_registry::get_or_emplace
-        * @tparam Component Type of component to get.
-        * @tparam Args Types of arguments to use to construct the component.
-        * @param args Parameters to use to initialize the component.
-        * @return Reference to the component owned by the handle.
-        */
-        template<typename Component, typename... Args>
-        [[nodiscard]] decltype(auto) get_or_emplace(Args &&... args) const {
-            return reg->template get_or_emplace<Component>(entt, std::forward<Args>(args)...);
-        }
-
-        /**
-        * @brief Returns pointers to the given components for a handle.
-        * @sa basic_registry::try_get
-        * @tparam Component Types of components to get.
-        * @return Pointers to the components owned by the handle.
-        */
-        template<typename... Components>
-        [[nodiscard]] decltype(auto) try_get() const {
-            return reg->template try_get<Components...>(entt);
-        }
-
-        /**
-        * @brief Checks if a handle has components assigned.
-        * @return True if the handle has no components assigned, false otherwise.
-        */
-        [[nodiscard]] bool orphan() const {
-            return reg->orphan(entt);
-        }
-
-        /**
-        * @brief Visits a handle and returns the types for its components.
-        * @sa basic_registry::visit
-        * @tparam Func Type of the function object to invoke.
-        * @param func A valid function object.
-        */
-        template<typename Func>
-        void visit(Func &&func) const {
-            reg->visit(entt, std::forward<Func>(func));
-        }
-
-    private:
-        registry_type *reg;
-        entity_type entt;
-    };
-
+    /*! @brief Type of registry accepted by the handle. */
+    using registry_type = std::conditional_t<
+        std::is_const_v<Entity>,
+        const basic_registry<entity_type>,
+        basic_registry<entity_type>
+    >;
 
     /**
-    * @brief Deduction guide.
-    * @tparam Entity A valid entity type (see entt_traits for more details).
+    * @brief Constructs a default invalid handle.
     */
-    template<typename Entity>
-    basic_handle(basic_registry<Entity> &, Entity) -> basic_handle<Entity>;
-
+    basic_handle() ENTT_NOEXCEPT
+        : reg{nullptr}, entt{null}
+    {}
 
     /**
-    * @brief Deduction guide.
-    * @tparam Entity A valid entity type (see entt_traits for more details).
+    * @brief Constructs a handle from a given registry and entity.
+    * @param ref An instance of the registry class.
+    * @param value An entity identifier.
     */
-    template<typename Entity>
-    basic_handle(const basic_registry<Entity> &, Entity) -> basic_handle<const Entity>;
+    basic_handle(registry_type &ref, entity_type value) ENTT_NOEXCEPT
+        : reg{&ref}, entt{value}
+    {}
+
+    /**
+    * @brief Compares two handles.
+    * @return True if both handles refer to the same registry and the same entity, false otherwise.
+    */
+    bool operator==(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
+        return reg == other.registry() && entt == other.entity();
+    }
+
+    /**
+    * @brief Compares two handles.
+    * @return False if both handles refer to the same registry and the same entity, true otherwise.
+    */
+    bool operator!=(const basic_handle<entity_type> &other) const ENTT_NOEXCEPT {
+        return !(*this == other);
+    }
+
+    /**
+    * @brief Constructs a const handle from a non-const one.
+    * @return A const handle referring to the same entity.
+    */
+    [[nodiscard]] operator basic_handle<const entity_type>() const ENTT_NOEXCEPT {
+        return reg ? basic_handle<const entity_type>{*reg, entt} : basic_handle<const entity_type>{};
+    }
+
+    /**
+    * @brief Converts a handle to its underlying entity.
+    * @return An entity identifier.
+    */
+    [[nodiscard]] operator entity_type() const ENTT_NOEXCEPT {
+        return entity();
+    }
+
+    /**
+    * @brief Checks if a handle refers to non-null registry pointer and entity.
+    * @return True if the handle refers to non-null registry and entity, false otherwise.
+    */
+    [[nodiscard]] explicit operator bool() const {
+        return reg && entt != null;
+    }
+
+    /**
+    * @brief Checks if a handle refers to a valid entity or not.
+    * @return True if the handle refers to a valid entity, false otherwise.
+    */
+    [[nodiscard]] bool valid() const {
+        return reg->valid(entt);
+    }
+
+    /**
+    * @brief Returns a pointer to the underlying registry.
+    * @return A pointer to the underlying registry.
+    */
+    [[nodiscard]] registry_type * registry() const ENTT_NOEXCEPT {
+        return reg;
+    }
+
+    /**
+    * @brief Returns the entity associated with a handle.
+    * @param value he entity associated with the handle.
+    */
+    [[nodiscard]] entity_type entity() const ENTT_NOEXCEPT {
+        return entt;
+    }
+
+    /**
+    * @brief Assigns the given component to a handle.
+    * @sa basic_registry::emplace
+    * @tparam Component Type of component to create.
+    * @tparam Args Types of arguments to use to construct the component.
+    * @param args Parameters to use to initialize the component.
+    * @return A reference to the newly created component.
+    */
+    template<typename Component, typename... Args>
+    decltype(auto) emplace(Args &&... args) const {
+        return reg->template emplace<Component>(entt, std::forward<Args>(args)...);
+    }
+
+    /**
+    * @brief Assigns or replaces the given component for a handle.
+    * @sa basic_registry::emplace_or_replace
+    * @tparam Component Type of component to assign or replace.
+    * @tparam Args Types of arguments to use to construct the component.
+    * @param args Parameters to use to initialize the component.
+    * @return A reference to the newly created component.
+    */
+    template<typename Component, typename... Args>
+    decltype(auto) emplace_or_replace(Args &&... args) const {
+        return reg->template emplace_or_replace<Component>(entt, std::forward<Args>(args)...);
+    }
+
+    /**
+    * @brief Patches the given component for a handle.
+    * @sa basic_registry::patch
+    * @tparam Component Type of component to patch.
+    * @tparam Func Types of the function objects to invoke.
+    * @param func Valid function objects.
+    * @return A reference to the patched component.
+    */
+    template<typename Component, typename... Func>
+    decltype(auto) patch(Func &&... func) const {
+        return reg->template patch<Component>(entt, std::forward<Func>(func)...);
+    }
+
+    /**
+    * @brief Replaces the given component for a handle.
+    * @sa basic_registry::replace
+    * @tparam Component Type of component to replace.
+    * @tparam Args Types of arguments to use to construct the component.
+    * @param args Parameters to use to initialize the component.
+    * @return A reference to the component being replaced.
+    */
+    template<typename Component, typename... Args>
+    decltype(auto) replace(Args &&... args) const {
+        return reg->template replace<Component>(entt, std::forward<Args>(args)...);
+    }
+
+    /**
+    * @brief Removes the given components from a handle.
+    * @sa basic_registry::remove
+    * @tparam Component Types of components to remove.
+    */
+    template<typename... Components>
+    void remove() const {
+        reg->template remove<Components...>(entt);
+    }
+
+    /**
+    * @brief Removes the given components from a handle.
+    * @sa basic_registry::remove_if_exists
+    * @tparam Component Types of components to remove.
+    * @return The number of components actually removed.
+    */
+    template<typename... Components>
+    decltype(auto) remove_if_exists() const {
+        return reg->template remove_if_exists<Components...>(entt);
+    }
+
+    /**
+    * @brief Removes all the components from a handle and makes it orphaned.
+    * @sa basic_registry::remove_all
+    */
+    void remove_all() const {
+        reg->remove_all(entt);
+    }
+
+    /**
+    * @brief Checks if a handle has all the given components.
+    * @sa basic_registry::has
+    * @tparam Component Components for which to perform the check.
+    * @return True if the handle has all the components, false otherwise.
+    */
+    template<typename... Components>
+    [[nodiscard]] decltype(auto) has() const {
+        return reg->template has<Components...>(entt);
+    }
+
+    /**
+    * @brief Checks if a handle has at least one of the given components.
+    * @sa basic_registry::any
+    * @tparam Component Components for which to perform the check.
+    * @return True if the handle has at least one of the given components,
+    * false otherwise.
+    */
+    template<typename... Components>
+    [[nodiscard]] decltype(auto) any() const {
+        return reg->template any<Components...>(entt);
+    }
+
+    /**
+    * @brief Returns references to the given components for a handle.
+    * @sa basic_registry::get
+    * @tparam Component Types of components to get.
+    * @return References to the components owned by the handle.
+    */
+    template<typename... Components>
+    [[nodiscard]] decltype(auto) get() const {
+        return reg->template get<Components...>(entt);
+    }
+
+    /**
+    * @brief Returns a reference to the given component for a handle.
+    * @sa basic_registry::get_or_emplace
+    * @tparam Component Type of component to get.
+    * @tparam Args Types of arguments to use to construct the component.
+    * @param args Parameters to use to initialize the component.
+    * @return Reference to the component owned by the handle.
+    */
+    template<typename Component, typename... Args>
+    [[nodiscard]] decltype(auto) get_or_emplace(Args &&... args) const {
+        return reg->template get_or_emplace<Component>(entt, std::forward<Args>(args)...);
+    }
+
+    /**
+    * @brief Returns pointers to the given components for a handle.
+    * @sa basic_registry::try_get
+    * @tparam Component Types of components to get.
+    * @return Pointers to the components owned by the handle.
+    */
+    template<typename... Components>
+    [[nodiscard]] decltype(auto) try_get() const {
+        return reg->template try_get<Components...>(entt);
+    }
+
+    /**
+    * @brief Checks if a handle has components assigned.
+    * @return True if the handle has no components assigned, false otherwise.
+    */
+    [[nodiscard]] bool orphan() const {
+        return reg->orphan(entt);
+    }
+
+    /**
+    * @brief Visits a handle and returns the types for its components.
+    * @sa basic_registry::visit
+    * @tparam Func Type of the function object to invoke.
+    * @param func A valid function object.
+    */
+    template<typename Func>
+    void visit(Func &&func) const {
+        reg->visit(entt, std::forward<Func>(func));
+    }
+
+private:
+    registry_type *reg;
+    entity_type entt;
+};
+
+
+/**
+* @brief Deduction guide.
+* @tparam Entity A valid entity type (see entt_traits for more details).
+*/
+template<typename Entity>
+basic_handle(basic_registry<Entity> &, Entity) -> basic_handle<Entity>;
+
+
+/**
+* @brief Deduction guide.
+* @tparam Entity A valid entity type (see entt_traits for more details).
+*/
+template<typename Entity>
+basic_handle(const basic_registry<Entity> &, Entity) -> basic_handle<const Entity>;
 
 
 }

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -5,26 +5,22 @@
 #include <entt/entity/registry.hpp>
 
 TEST(BasicHandle, Assumptions) {
-    static_assert(std::is_trivially_copyable_v<entt::handle>);
-    static_assert(std::is_trivially_assignable_v<entt::handle, entt::handle>);
     static_assert(std::is_trivially_destructible_v<entt::handle>);
 
-    static_assert(std::is_trivially_copyable_v<entt::const_handle>);
-    static_assert(std::is_trivially_assignable_v<entt::const_handle, entt::const_handle>);
     static_assert(std::is_trivially_destructible_v<entt::const_handle>);
 }
 
 TEST(BasicHandle, DeductionGuide) {
-    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<entt::registry &>(), {}}), entt::basic_handle<entt::entity>>);
-    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<const entt::registry &>(), {}}), entt::basic_handle<const entt::entity>>);
+    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<entt::registry *>(), {}}), entt::basic_handle<entt::entity>>);
+    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<const entt::registry *>(), {}}), entt::basic_handle<const entt::entity>>);
 }
 
 TEST(BasicHandle, Construction) {
     entt::registry registry;
     const auto entity = registry.create();
 
-    entt::handle handle{registry, entity};
-    entt::const_handle chandle{std::as_const(registry), entity};
+    entt::handle handle{&registry, entity};
+    entt::const_handle chandle{&std::as_const(registry), entity};
 
     ASSERT_FALSE(entt::null == handle.entity());
     ASSERT_EQ(entity, handle);
@@ -36,8 +32,8 @@ TEST(BasicHandle, Construction) {
 
     ASSERT_EQ(handle, chandle);
 
-    static_assert(std::is_same_v<entt::registry &, decltype(handle.registry())>);
-    static_assert(std::is_same_v<const entt::registry &, decltype(chandle.registry())>);
+    static_assert(std::is_same_v<entt::registry *, decltype(handle.registry())>);
+    static_assert(std::is_same_v<const entt::registry *, decltype(chandle.registry())>);
 
     handle = entt::null;
 
@@ -51,7 +47,7 @@ TEST(BasicHandle, Construction) {
 TEST(BasicHandle, Component) {
     entt::registry registry;
     const auto entity = registry.create();
-    entt::handle handle{registry, entity};
+    entt::handle handle{&registry, entity};
 
     ASSERT_EQ(3, handle.emplace<int>(3));
     ASSERT_EQ('c', handle.emplace_or_replace<char>('c'));
@@ -93,7 +89,7 @@ TEST(BasicHandle, FromEntity) {
     registry.emplace<int>(entity, 42);
     registry.emplace<char>(entity, 'c');
 
-    entt::handle handle{registry, entity};
+    entt::handle handle{&registry, entity};
 
     ASSERT_TRUE(handle);
     ASSERT_EQ(entity, handle.entity());
@@ -105,7 +101,7 @@ TEST(BasicHandle, FromEntity) {
 TEST(BasicHandle, Lifetime) {
     entt::registry registry;
     const auto entity = registry.create();
-    auto *handle = new entt::handle{registry, entity};
+    auto *handle = new entt::handle{&registry, entity};
     handle->emplace<int>();
 
     ASSERT_FALSE(registry.empty<int>());
@@ -123,7 +119,7 @@ TEST(BasicHandle, Lifetime) {
 
 TEST(BasicHandle, ImplicitConversions) {
     entt::registry registry;
-    const entt::handle handle{registry, registry.create()};
+    const entt::handle handle{&registry, registry.create()};
     const entt::const_handle chandle = handle;
 
     handle.emplace<int>(42);

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -45,9 +45,7 @@ TEST(BasicHandle, Invalidation) {
     entt::handle handle;
 
     ASSERT_TRUE(nullptr == handle.registry());
-    ASSERT_EQ(handle.registry(), nullptr);
     ASSERT_TRUE(entt::null == handle.entity());
-    ASSERT_EQ(handle.entity(), entt::null);
     ASSERT_FALSE(handle);
 
     entt::registry registry;
@@ -56,17 +54,13 @@ TEST(BasicHandle, Invalidation) {
     handle = {registry, entity};
 
     ASSERT_FALSE(nullptr == handle.registry());
-    ASSERT_NE(handle.registry(), nullptr);
     ASSERT_FALSE(entt::null == handle.entity());
-    ASSERT_NE(handle.entity(), entt::null);
     ASSERT_TRUE(handle);
 
     handle = {};
 
     ASSERT_TRUE(nullptr == handle.registry());
-    ASSERT_EQ(handle.registry(), nullptr);
     ASSERT_TRUE(entt::null == handle.entity());
-    ASSERT_EQ(handle.entity(), entt::null);
     ASSERT_FALSE(handle);
 }
 

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -119,15 +119,15 @@ TEST(BasicHandle, Comparison) {
     ASSERT_FALSE(handle1 != chandle2);
 
     handle2 = {};
-    chandle2 = {};
+    chandle1 = {};
 
-    ASSERT_NE(handle1, handle2);
-    ASSERT_FALSE(handle1 == handle2);
-    ASSERT_TRUE(handle1 != handle2);
+    ASSERT_EQ(handle1, handle2);
+    ASSERT_TRUE(handle1 == handle2);
+    ASSERT_FALSE(handle1 != handle2);
 
-    ASSERT_NE(chandle1, chandle2);
-    ASSERT_FALSE(chandle1 == chandle2);
-    ASSERT_TRUE(chandle1 != chandle2);
+    ASSERT_EQ(chandle1, chandle2);
+    ASSERT_TRUE(chandle1 == chandle2);
+    ASSERT_FALSE(chandle1 != chandle2);
 
     ASSERT_EQ(handle1, chandle1);
     ASSERT_TRUE(handle1 == chandle1);
@@ -137,9 +137,9 @@ TEST(BasicHandle, Comparison) {
     ASSERT_TRUE(handle2 == chandle2);
     ASSERT_FALSE(handle2 != chandle2);
 
-    ASSERT_NE(handle1, chandle2);
-    ASSERT_FALSE(handle1 == chandle2);
-    ASSERT_TRUE(handle1 != chandle2);
+    ASSERT_EQ(handle1, chandle2);
+    ASSERT_TRUE(handle1 == chandle2);
+    ASSERT_FALSE(handle1 != chandle2);
 
     entt::registry registry_b;
     const auto entity_b1 = registry.create();
@@ -157,13 +157,13 @@ TEST(BasicHandle, Comparison) {
     ASSERT_FALSE(chandle1 == chandle2);
     ASSERT_TRUE(chandle1 != chandle2);
 
-    ASSERT_NE(handle1, chandle1);
-    ASSERT_FALSE(handle1 == chandle1);
-    ASSERT_TRUE(handle1 != chandle1);
+    ASSERT_EQ(handle1, chandle1);
+    ASSERT_TRUE(handle1 == chandle1);
+    ASSERT_FALSE(handle1 != chandle1);
 
-    ASSERT_NE(handle2, chandle2);
-    ASSERT_FALSE(handle2 == chandle2);
-    ASSERT_TRUE(handle2 != chandle2);
+    ASSERT_EQ(handle2, chandle2);
+    ASSERT_TRUE(handle2 == chandle2);
+    ASSERT_FALSE(handle2 != chandle2);
 
     ASSERT_NE(handle1, chandle2);
     ASSERT_FALSE(handle1 == chandle2);

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -39,7 +39,7 @@ TEST(BasicHandle, Construction) {
     static_assert(std::is_same_v<entt::registry *, decltype(handle.registry())>);
     static_assert(std::is_same_v<const entt::registry *, decltype(chandle.registry())>);
 
-    handle.entity(entt::null);
+    handle = {};
 
     ASSERT_TRUE(entt::null == handle.entity());
     ASSERT_NE(entity, handle);

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -5,22 +5,26 @@
 #include <entt/entity/registry.hpp>
 
 TEST(BasicHandle, Assumptions) {
+    static_assert(std::is_trivially_copyable_v<entt::handle>);
+    static_assert(std::is_trivially_assignable_v<entt::handle, entt::handle>);
     static_assert(std::is_trivially_destructible_v<entt::handle>);
 
+    static_assert(std::is_trivially_copyable_v<entt::const_handle>);
+    static_assert(std::is_trivially_assignable_v<entt::const_handle, entt::const_handle>);
     static_assert(std::is_trivially_destructible_v<entt::const_handle>);
 }
 
 TEST(BasicHandle, DeductionGuide) {
-    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<entt::registry *>(), {}}), entt::basic_handle<entt::entity>>);
-    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<const entt::registry *>(), {}}), entt::basic_handle<const entt::entity>>);
+    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<entt::registry &>(), {}}), entt::basic_handle<entt::entity>>);
+    static_assert(std::is_same_v<decltype(entt::basic_handle{std::declval<const entt::registry &>(), {}}), entt::basic_handle<const entt::entity>>);
 }
 
 TEST(BasicHandle, Construction) {
     entt::registry registry;
     const auto entity = registry.create();
 
-    entt::handle handle{&registry, entity};
-    entt::const_handle chandle{&std::as_const(registry), entity};
+    entt::handle handle{registry, entity};
+    entt::const_handle chandle{std::as_const(registry), entity};
 
     ASSERT_FALSE(entt::null == handle.entity());
     ASSERT_EQ(entity, handle);
@@ -35,7 +39,7 @@ TEST(BasicHandle, Construction) {
     static_assert(std::is_same_v<entt::registry *, decltype(handle.registry())>);
     static_assert(std::is_same_v<const entt::registry *, decltype(chandle.registry())>);
 
-    handle = entt::null;
+    handle.entity(entt::null);
 
     ASSERT_TRUE(entt::null == handle.entity());
     ASSERT_NE(entity, handle);
@@ -47,7 +51,7 @@ TEST(BasicHandle, Construction) {
 TEST(BasicHandle, Component) {
     entt::registry registry;
     const auto entity = registry.create();
-    entt::handle handle{&registry, entity};
+    entt::handle handle{registry, entity};
 
     ASSERT_EQ(3, handle.emplace<int>(3));
     ASSERT_EQ('c', handle.emplace_or_replace<char>('c'));
@@ -89,7 +93,7 @@ TEST(BasicHandle, FromEntity) {
     registry.emplace<int>(entity, 42);
     registry.emplace<char>(entity, 'c');
 
-    entt::handle handle{&registry, entity};
+    entt::handle handle{registry, entity};
 
     ASSERT_TRUE(handle);
     ASSERT_EQ(entity, handle.entity());
@@ -101,7 +105,7 @@ TEST(BasicHandle, FromEntity) {
 TEST(BasicHandle, Lifetime) {
     entt::registry registry;
     const auto entity = registry.create();
-    auto *handle = new entt::handle{&registry, entity};
+    auto *handle = new entt::handle{registry, entity};
     handle->emplace<int>();
 
     ASSERT_FALSE(registry.empty<int>());
@@ -119,7 +123,7 @@ TEST(BasicHandle, Lifetime) {
 
 TEST(BasicHandle, ImplicitConversions) {
     entt::registry registry;
-    const entt::handle handle{&registry, registry.create()};
+    const entt::handle handle{registry, registry.create()};
     const entt::const_handle chandle = handle;
 
     handle.emplace<int>(42);

--- a/test/entt/entity/handle.cpp
+++ b/test/entt/entity/handle.cpp
@@ -38,15 +38,144 @@ TEST(BasicHandle, Construction) {
 
     static_assert(std::is_same_v<entt::registry *, decltype(handle.registry())>);
     static_assert(std::is_same_v<const entt::registry *, decltype(chandle.registry())>);
+}
+
+
+TEST(BasicHandle, Invalidation) {
+    entt::handle handle;
+
+    ASSERT_TRUE(nullptr == handle.registry());
+    ASSERT_EQ(handle.registry(), nullptr);
+    ASSERT_TRUE(entt::null == handle.entity());
+    ASSERT_EQ(handle.entity(), entt::null);
+    ASSERT_FALSE(handle);
+
+    entt::registry registry;
+    const auto entity = registry.create();
+
+    handle = {registry, entity};
+
+    ASSERT_FALSE(nullptr == handle.registry());
+    ASSERT_NE(handle.registry(), nullptr);
+    ASSERT_FALSE(entt::null == handle.entity());
+    ASSERT_NE(handle.entity(), entt::null);
+    ASSERT_TRUE(handle);
 
     handle = {};
 
+    ASSERT_TRUE(nullptr == handle.registry());
+    ASSERT_EQ(handle.registry(), nullptr);
     ASSERT_TRUE(entt::null == handle.entity());
-    ASSERT_NE(entity, handle);
+    ASSERT_EQ(handle.entity(), entt::null);
     ASSERT_FALSE(handle);
-
-    ASSERT_NE(handle, chandle);
 }
+
+
+TEST(BasicHandle, Comparison) {
+    entt::registry registry;
+    const auto entity1 = registry.create();
+    const auto entity2 = registry.create();
+
+    entt::handle handle1{registry, entity1};
+    entt::handle handle2{registry, entity2};
+    entt::const_handle chandle1 = handle1;
+    entt::const_handle chandle2 = handle2;
+
+    ASSERT_NE(handle1, handle2);
+    ASSERT_FALSE(handle1 == handle2);
+    ASSERT_TRUE(handle1 != handle2);
+
+    ASSERT_NE(chandle1, chandle2);
+    ASSERT_FALSE(chandle1 == chandle2);
+    ASSERT_TRUE(chandle1 != chandle2);
+
+    ASSERT_EQ(handle1, chandle1);
+    ASSERT_TRUE(handle1 == chandle1);
+    ASSERT_FALSE(handle1 != chandle1);
+
+    ASSERT_EQ(handle2, chandle2);
+    ASSERT_TRUE(handle2 == chandle2);
+    ASSERT_FALSE(handle2 != chandle2);
+
+    ASSERT_NE(handle1, chandle2);
+    ASSERT_FALSE(handle1 == chandle2);
+    ASSERT_TRUE(handle1 != chandle2);
+
+    handle1 = {};
+    chandle2 = {};
+
+    ASSERT_NE(handle1, handle2);
+    ASSERT_FALSE(handle1 == handle2);
+    ASSERT_TRUE(handle1 != handle2);
+
+    ASSERT_NE(chandle1, chandle2);
+    ASSERT_FALSE(chandle1 == chandle2);
+    ASSERT_TRUE(chandle1 != chandle2);
+
+    ASSERT_NE(handle1, chandle1);
+    ASSERT_FALSE(handle1 == chandle1);
+    ASSERT_TRUE(handle1 != chandle1);
+
+    ASSERT_NE(handle2, chandle2);
+    ASSERT_FALSE(handle2 == chandle2);
+    ASSERT_TRUE(handle2 != chandle2);
+
+    ASSERT_EQ(handle1, chandle2);
+    ASSERT_TRUE(handle1 == chandle2);
+    ASSERT_FALSE(handle1 != chandle2);
+
+    handle2 = {};
+    chandle2 = {};
+
+    ASSERT_NE(handle1, handle2);
+    ASSERT_FALSE(handle1 == handle2);
+    ASSERT_TRUE(handle1 != handle2);
+
+    ASSERT_NE(chandle1, chandle2);
+    ASSERT_FALSE(chandle1 == chandle2);
+    ASSERT_TRUE(chandle1 != chandle2);
+
+    ASSERT_EQ(handle1, chandle1);
+    ASSERT_TRUE(handle1 == chandle1);
+    ASSERT_FALSE(handle1 != chandle1);
+
+    ASSERT_EQ(handle2, chandle2);
+    ASSERT_TRUE(handle2 == chandle2);
+    ASSERT_FALSE(handle2 != chandle2);
+
+    ASSERT_NE(handle1, chandle2);
+    ASSERT_FALSE(handle1 == chandle2);
+    ASSERT_TRUE(handle1 != chandle2);
+
+    entt::registry registry_b;
+    const auto entity_b1 = registry.create();
+
+    handle1 = {registry_b, entity_b1};
+    handle2 = {registry, entity1};
+    chandle1 = handle1;
+    chandle2 = handle2;
+
+    ASSERT_NE(handle1, handle2);
+    ASSERT_FALSE(handle1 == handle2);
+    ASSERT_TRUE(handle1 != handle2);
+
+    ASSERT_NE(chandle1, chandle2);
+    ASSERT_FALSE(chandle1 == chandle2);
+    ASSERT_TRUE(chandle1 != chandle2);
+
+    ASSERT_NE(handle1, chandle1);
+    ASSERT_FALSE(handle1 == chandle1);
+    ASSERT_TRUE(handle1 != chandle1);
+
+    ASSERT_NE(handle2, chandle2);
+    ASSERT_FALSE(handle2 == chandle2);
+    ASSERT_TRUE(handle2 != chandle2);
+
+    ASSERT_NE(handle1, chandle2);
+    ASSERT_FALSE(handle1 == chandle2);
+    ASSERT_TRUE(handle1 != chandle2);
+}
+
 
 TEST(BasicHandle, Component) {
     entt::registry registry;


### PR DESCRIPTION
Following the brief discussion on Discord after my initial impressions of `entt::handle` that were introduced in #513 I'm creating a pull request with proposed changes.

This is a draft and the code will probably change after discussions or will be rejected, so I only changed tests to compile with the current code but didn't add new ones yet or fix the failures. I didn't update the documentation too.

### What's the issue with `entt::handle` in its current form?

It's not possible to store a default initialized and truly invalid handle that doesn't point to any registry and entity.

### Why is that needed?

In my case there are a lot of types that live outside the ECS and point to certain entities in order to inspect them or operate on them. Not pointing to any entity is also a valid case though. Current `entt::handle` makes the described approach much less elegant since it has to be initialized with at least a valid `entt::registry` instance.

### What is the alternative?

I could write my own handle but it would duplicate a major part of `entt::handle` code. I could also wrap it in `std::optional` but that adds unnecessary payload and has a duplicated feature smell to it. Another solution would be to wrap it in a custom type and apply some kind of union hackery to interpret `nullptr` in the first `sizeof(void*)` bytes of the handle as an invalid state.

### What changes?

`entt::handle` takes an `entt::registry` pointer instead of a reference in its constructor. It also has a default constructor. Storing a `nullptr` is fine and part of its functionality now. A few other changes were also done in regards to comparisions, construction and assignments.