### PR TITLE
Data and func shortcuts

### DIFF
--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -1468,7 +1468,7 @@ public:
      * functions and properties, as well as its constructors, destructors and
      * conversion functions if any.<br/>
      * Base classes aren't reset but the link between the two types is removed.
-     * 
+     *
      * The meta type is also removed from the list of searchable types.
      */
     void reset() ENTT_NOEXCEPT {
@@ -1492,14 +1492,14 @@ public:
                 }
             }
         };
-        
+
         unregister_all(&node->prop);
         unregister_all(&node->base);
         unregister_all(&node->conv);
         unregister_all(&node->ctor, &internal::meta_ctor_node::prop);
         unregister_all(&node->data, &internal::meta_data_node::prop);
         unregister_all(&node->func, &internal::meta_func_node::prop);
-        
+
         node->id = {};
         node->dtor = nullptr;
     }

--- a/test/entt/meta/meta_type.cpp
+++ b/test/entt/meta/meta_type.cpp
@@ -270,6 +270,9 @@ TEST_F(MetaType, Func) {
     ASSERT_TRUE(type.func("func"_hs));
     ASSERT_TRUE(type.func("member"_hs).invoke(instance));
     ASSERT_TRUE(type.func("func"_hs).invoke({}));
+
+    ASSERT_TRUE(type.invoke("member"_hs, instance));
+    ASSERT_TRUE(type.invoke("func"_hs, {}));
 }
 
 TEST_F(MetaType, Construct) {


### PR DESCRIPTION
Implemented shortcuts for invoking meta-functions and getting and setting meta-data directly from `meta_type` and `meta_any` instances.

I'll sign commits a bit later - don't have my key with me now.

Once PR is reviewed, I'll squash things.

I suggest cherry-picking the trailing spaces fixing commit even without PR.