### PR TITLE
Prefix CMake Variables with ENTT.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         CXX: ${{ matrix.compiler }}
       run: |
-        cmake -DBUILD_LIB=ON -DBUILD_EXAMPLE=ON ..
+        cmake -DENTT_BUILD_LIB=ON -DENTT_BUILD_EXAMPLE=ON ..
         make -j4
     - name: Run tests
       working-directory: build
@@ -53,7 +53,7 @@ jobs:
     - name: Compile tests
       working-directory: build
       run: |
-        cmake -DBUILD_LIB=ON -DBUILD_EXAMPLE=ON ${{ matrix.toolset_option }} ..
+        cmake -DENTT_BUILD_LIB=ON -DENTT_BUILD_EXAMPLE=ON ${{ matrix.toolset_option }} ..
         cmake --build . -j 4
     - name: Run tests
       working-directory: build
@@ -70,7 +70,7 @@ jobs:
     - name: Compile tests
       working-directory: build
       run: |
-        cmake -DBUILD_LIB=ON -DBUILD_EXAMPLE=ON ..
+        cmake -DENTT_BUILD_LIB=ON -DENTT_BUILD_EXAMPLE=ON ..
         make -j4
     - name: Run tests
       working-directory: build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
         CXXFLAGS: "-O0 --coverage -fno-inline -fno-inline-small-functions -fno-default-inline"
         CXX: g++
       run: |
-        cmake -DBUILD_LIB=ON -DBUILD_EXAMPLE=ON ..
+        cmake -DENTT_BUILD_LIB=ON -DENTT_BUILD_EXAMPLE=ON ..
         make -j4
     - name: Run tests
       working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,14 +42,14 @@ message(VERBOSE "* ${PROJECT_NAME} v${PROJECT_VERSION} (${CMAKE_BUILD_TYPE})")
 message(VERBOSE "* Copyright (c) 2017-2020 Michele Caini <michele.caini@gmail.com>")
 message(VERBOSE "*")
 
-option(USE_LIBCPP "Use libc++ by adding -stdlib=libc++ flag if availbale." ON)
-option(USE_ASAN "Use address sanitizer by adding -fsanitize=address -fno-omit-frame-pointer flags" OFF)
+option(ENTT_USE_LIBCPP "Use libc++ by adding -stdlib=libc++ flag if availbale." ON)
+option(ENTT_USE_ASAN "Use address sanitizer by adding -fsanitize=address -fno-omit-frame-pointer flags" OFF)
 
 #
 # Compiler stuff
 #
 
-if(NOT WIN32 AND USE_LIBCPP)
+if(NOT WIN32 AND ENTT_USE_LIBCPP)
     include(CheckCXXSourceCompiles)
     include(CMakePushCheckState)
 
@@ -60,10 +60,10 @@ if(NOT WIN32 AND USE_LIBCPP)
     check_cxx_source_compiles("
         #include<type_traits>
         int main() { return std::is_same_v<int, char>; }
-    " HAS_LIBCPP)
+    " ENTT_HAS_LIBCPP)
 
-    if(NOT HAS_LIBCPP)
-        message(VERBOSE "The option USE_LIBCPP is set (by default) but libc++ is not available. The flag will not be added to the target.")
+    if(NOT ENTT_HAS_LIBCPP)
+        message(VERBOSE "The option ENTT_USE_LIBCPP is set (by default) but libc++ is not available. The flag will not be added to the target.")
     endif()
 
     cmake_pop_check_state()
@@ -85,12 +85,12 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if(USE_ASAN)
+if(ENTT_USE_ASAN)
     target_compile_options(EnTT INTERFACE $<$<CONFIG:Debug>:-fsanitize=address -fno-omit-frame-pointer>)
     target_link_libraries(EnTT INTERFACE $<$<CONFIG:Debug>:-fsanitize=address -fno-omit-frame-pointer>)
 endif()
 
-if(HAS_LIBCPP)
+if(ENTT_HAS_LIBCPP)
     target_compile_options(EnTT BEFORE INTERFACE -stdlib=libc++)
 endif()
 
@@ -150,12 +150,12 @@ export(PACKAGE EnTT)
 
 include(CTest)
 
-if(BUILD_TESTING)
-    option(FIND_GTEST_PACKAGE "Enable finding gtest package." OFF)
-    option(BUILD_BENCHMARK "Build benchmark." OFF)
-    option(BUILD_EXAMPLE "Build examples." OFF)
-    option(BUILD_LIB "Build lib tests." OFF)
-    option(BUILD_SNAPSHOT "Build snapshot test with Cereal." OFF)
+if(ENTT_BUILD_TESTING)
+    option(ENTT_FIND_GTEST_PACKAGE "Enable finding gtest package." OFF)
+    option(ENTT_BUILD_BENCHMARK "Build benchmark." OFF)
+    option(ENTT_BUILD_EXAMPLE "Build examples." OFF)
+    option(ENTT_BUILD_LIB "Build lib tests." OFF)
+    option(ENTT_BUILD_SNAPSHOT "Build snapshot test with Cereal." OFF)
 
     enable_testing()
     add_subdirectory(test)
@@ -165,9 +165,9 @@ endif()
 # Documentation
 #
 
-option(BUILD_DOCS "Enable building with documentation." OFF)
+option(ENTT_BUILD_DOCS "Enable building with documentation." OFF)
 
-if(BUILD_DOCS)
+if(ENTT_BUILD_DOCS)
     find_package(Doxygen 1.8)
 
     if(DOXYGEN_FOUND)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ reasons.
 
 If you are interested, you can compile the `benchmark` test in release mode (to
 enable compiler optimizations, otherwise it would make little sense) by setting
-the `BUILD_BENCHMARK` option of `CMake` to `ON`, then evaluate yourself whether
+the `ENTT_BUILD_BENCHMARK` option of `CMake` to `ON`, then evaluate yourself whether
 you're satisfied with the results or not.
 
 Honestly I got tired of updating the README file whenever there is an
@@ -258,7 +258,7 @@ The documentation is based on [doxygen](http://www.doxygen.nl/).
 To build it:
 
     $ cd build
-    $ cmake .. -DBUILD_DOCS=ON
+    $ cmake .. -DENTT_BUILD_DOCS=ON
     $ make
 
 The API reference will be created in HTML format within the directory
@@ -285,12 +285,12 @@ to the project where users can find all related documentation pages.
 
 To compile and run the tests, `EnTT` requires *googletest*.<br/>
 `cmake` will download and compile the library before compiling anything else.
-In order to build the tests, set the CMake option `BUILD_TESTING` to `ON`.
+In order to build the tests, set the CMake option `ENTT_BUILD_TESTING` to `ON`.
 
 To build the most basic set of tests:
 
 * `$ cd build`
-* `$ cmake -DBUILD_TESTING=ON ..`
+* `$ cmake -DENTT_BUILD_TESTING=ON ..`
 * `$ make`
 * `$ make test`
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-if(FIND_GTEST_PACKAGE)
+if(ENTT_FIND_GTEST_PACKAGE)
     find_package(GTest REQUIRED)
 else()
     FetchContent_Declare(
@@ -89,20 +89,20 @@ endfunction()
 
 # Test benchmark
 
-if(BUILD_BENCHMARK)
+if(ENTT_BUILD_BENCHMARK)
     SETUP_BASIC_TEST(benchmark benchmark/benchmark.cpp)
 endif()
 
 # Test example
 
-if(BUILD_EXAMPLE)
+if(ENTT_BUILD_EXAMPLE)
     SETUP_BASIC_TEST(custom_identifier example/custom_identifier.cpp)
     SETUP_BASIC_TEST(multi_instance_storage example/multi_instance_storage.cpp)
 endif()
 
 # Test lib
 
-if(BUILD_LIB)
+if(ENTT_BUILD_LIB)
     FetchContent_Declare(
         cr
         GIT_REPOSITORY https://github.com/fungos/cr.git
@@ -132,7 +132,7 @@ endif()
 
 # Test snapshot
 
-if(BUILD_SNAPSHOT)
+if(ENTT_BUILD_SNAPSHOT)
     FetchContent_Declare(
         cereal
         GIT_REPOSITORY https://github.com/USCiLab/cereal.git


### PR DESCRIPTION
Fixes #584 

Cache variables as well as normal variable names have been prefixed with ENTT. Relevant changes have been made to the README and workflow files.