### PR TITLE
Bring back ENTT_DISABLE_ASSERT

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -27,8 +27,12 @@
 
 
 #ifndef ENTT_ASSERT
-#   include <cassert>
-#   define ENTT_ASSERT(condition) assert(condition)
+#   ifndef ENTT_DISABLE_ASSERT
+#       include <cassert>
+#       define ENTT_ASSERT(condition) assert(condition)
+#   else
+#       define ENTT_ASSERT(...) ((void)0)
+#   endif
 #endif
 
 


### PR DESCRIPTION
This allows EnTT asserts to be disabled via a compiler option by defining ENTT_DISABLE_ASSERT.