### PR TITLE
Delete @bazel_tools//src/conditions:windows_msys.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,6 @@ cc_library(
     copts = select({
       "@bazel_tools//src/conditions:windows": _msvc_copts,
       "@bazel_tools//src/conditions:windows_msvc": _msvc_copts,
-      "@bazel_tools//src/conditions:windows_msys": _msvc_copts,
       "//conditions:default": _gcc_copts,
     }),
 )


### PR DESCRIPTION
This condition is no longer available from Bazel 4.0.0, and when included a `WORKSPACE` built under Bazel 4.0.0, the following error occurs:

```
% blaze build @entt//:entt
ERROR: While resolving configuration keys for @entt//:entt: no such target '@bazel_tools//src/conditions:windows_msys': target 'windows_msys' not declared in package 'src/conditions' (did you mean 'windows_msvc'?) defined by /private/var/tmp/_bazel_warriorstar/e141537f37e88264e88943d724bc897e/external/bazel_tools/src/conditions/BUILD
ERROR: Analysis of target '@entt//:entt' failed; build aborted: no such target '@bazel_tools//src/conditions:windows_msys': target 'windows_msys' not declared in package 'src/conditions' (did you mean 'windows_msvc'?) defined by /private/var/tmp/_bazel_warriorstar/e141537f37e88264e88943d724bc897e/external/bazel_tools/src/conditions/BUILD
INFO: Elapsed time: 3.190s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (13 packages loaded, 101 targets configured)
```