### PR TITLE
build system: add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,12 @@ endif()
 target_compile_features(EnTT INTERFACE cxx_std_17)
 
 #
+# Set pkg-config variables
+#
+set(EnTT_PKGCONFIG ${PROJECT_BINARY_DIR}/entt.pc)
+set(EnTT_PKGCONFIG_DESTDIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+#
 # Install EnTT
 #
 
@@ -112,6 +118,12 @@ write_basic_package_version_file(
     EnTTConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
+)
+
+configure_file(
+  "${EnTT_SOURCE_DIR}/cmake/in/entt.pc.in"
+  "${EnTT_PKGCONFIG}"
+  @ONLY
 )
 
 configure_package_config_file(
@@ -141,6 +153,8 @@ install(
 )
 
 install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES "${EnTT_PKGCONFIG}" DESTINATION "${EnTT_PKGCONFIG_DESTDIR}")
 
 export(PACKAGE EnTT)
 

--- a/cmake/in/entt.pc.in
+++ b/cmake/in/entt.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: EnTT
+Description: Fast and reliable entity component system (ECS)
+Url: https://github.com/skypjack/entt
+Version: @EnTT_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
Closes #673.

This will generate a new file called `entt.pc`, which can be used by pkg-config to provide compiler flags for EnTT.

Installing EnTT like this:
```
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_INSTALL_PREFIX:PATH=~/entt-install
$ make
$ make install
```
will provide the file in `~/entt-install/lib64/pkgconfig/entt.pc`.

If this file can be found in a folder from `PKG_CONFIG_PATH`, then `pkg-config --cflags entt` will provide the include flag for the compiler.
```
$ PKG_CONFIG_PATH=~/entt-install/lib64/pkgconfig pkg-config --cflags entt
-I/home/seamas/entt-install/include
```
This will make it easy for distro maintainers to install the library so build systems (like Meson, for example) can find that EnTT is installed on the system and include it automatically in projects.

Side note: I tested this by packaging this commit for Guix and it works fine. Meson can find EnTT, my project builds and pkg-config works manually too:
```
$ pkg-config --cflags entt
-I/gnu/store/2xwlnq51jfjc0rp89j62926rlvfiy478-entt-v3.6.0-1.ea21a7d/include
```