### PR TITLE
fix warning for discarding a nodiscard

### DIFF
--- a/src/entt/entity/snapshot.hpp
+++ b/src/entt/entity/snapshot.hpp
@@ -55,7 +55,7 @@ class basic_snapshot {
 
         while(begin != last) {
             const auto entt = *(begin++);
-            ((reg->template all_of<Component>(entt) ? ++size[Index] : 0), ...);
+            ((reg->template all_of<Component>(entt) ? ++size[Index] : 0u), ...);
         }
 
         (get<Component>(archive, size[Index], first, last), ...);

--- a/src/entt/entity/snapshot.hpp
+++ b/src/entt/entity/snapshot.hpp
@@ -55,7 +55,7 @@ class basic_snapshot {
 
         while(begin != last) {
             const auto entt = *(begin++);
-            ((reg->template all_of<Component>(entt) ? ++size[Index] : size[Index]), ...);
+            ((reg->template all_of<Component>(entt) ? ++size[Index] : 0), ...);
         }
 
         (get<Component>(archive, size[Index], first, last), ...);


### PR DESCRIPTION
In MSVC the `std::array::operator[]` is `[[nodiscard]]` and the return value is discarded in `snapshot.hpp`

I only got this warning when using MSVC.
Compilers tested:
```
MSVC 19.29.30038.1
gcc-9.3
```