### PR TITLE
Attempt to make header files for EnTT show up in IDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ include(GNUInstallDirs)
 add_library(EnTT INTERFACE)
 add_library(EnTT::EnTT ALIAS EnTT)
 
+file(GLOB_RECURSE EnTT_H_FILES CONFIGURE_DEPENDS $<BUILD_INTERFACE:${EnTT_SOURCE_DIR}/src>/*.h)
+file(GLOB_RECURSE EnTT_HPP_FILES CONFIGURE_DEPENDS $<BUILD_INTERFACE:${EnTT_SOURCE_DIR}/src>/*.hpp)
+target_sources(EnTT INTERFACE "${EnTT_H_FILES}" "${EnTT_HPP_FILES}")
+
 target_include_directories(
     EnTT
     INTERFACE


### PR DESCRIPTION
I use QtCreator when programming on linux. When working with a project that consumes EnTT, if I navigate to the EnTT folder and tell the IDE to expand the EnTT target, it displays none of the headers.

This isn't so much an EnTT bug as it is an annoying cross-complication between CMake, the way CMake does header-only libs, QtCreator, and the specifics of the EnTT CMakeLists.txt file.

This change attempts to properly describe to any IDEs that the EnTT interface library has, as header files, anything under the "src" directory.

Whether a specific IDE will recognize this and properly display the headers for the EnTT target is up to that IDE.

Note that this also will cause a newly created headerfile, or a deleted header file, in the EnTT src/ folder to re-generate CMake, which I think is desirable, but others may not.