### PR TITLE
Add basic_any::is<Type>() and use it to speed up basic_registry::ctx

### DIFF
--- a/src/entt/core/any.hpp
+++ b/src/entt/core/any.hpp
@@ -252,6 +252,16 @@ public:
     }
 
     /**
+     * @brief Checks if the contained object has a given type.
+     * @tparam Type Type to query.
+     * @return True if the type matches, false otherwise.
+     */
+    template<typename Type>
+    [[nodiscard]] bool is() const ENTT_NOEXCEPT {
+        return vtable == &basic_vtable<std::remove_const_t<std::remove_reference_t<Type>>>;
+    }
+
+    /**
      * @brief Returns an opaque pointer to the contained instance.
      * @return An opaque pointer the contained instance, if any.
      */
@@ -298,7 +308,7 @@ public:
      */
     bool operator==(const basic_any &other) const ENTT_NOEXCEPT {
         const basic_any *trampoline = &other;
-        return type() == other.type() && (vtable(operation::COMP, *this, &trampoline) || !other.data());
+        return vtable == other.vtable && (vtable(operation::COMP, *this, &trampoline) || !other.data());
     }
 
     /**
@@ -389,7 +399,7 @@ Type any_cast(basic_any<Len, Align> &&data) ENTT_NOEXCEPT {
 /*! @copydoc any_cast */
 template<typename Type, std::size_t Len, std::size_t Align>
 const Type * any_cast(const basic_any<Len, Align> *data) ENTT_NOEXCEPT {
-    return (data->type() == type_id<Type>() ? static_cast<const Type *>(data->data()) : nullptr);
+    return (data->template is<Type>() ? static_cast<const Type *>(data->data()) : nullptr);
 }
 
 
@@ -397,7 +407,7 @@ const Type * any_cast(const basic_any<Len, Align> *data) ENTT_NOEXCEPT {
 template<typename Type, std::size_t Len, std::size_t Align>
 Type * any_cast(basic_any<Len, Align> *data) ENTT_NOEXCEPT {
     // last attempt to make wrappers for const references return their values
-    return (data->type() == type_id<Type>() ? static_cast<Type *>(static_cast<constness_as_t<basic_any<Len, Align>, Type> *>(data)->data()) : nullptr);
+    return (data->template is<Type>() ? static_cast<Type *>(static_cast<constness_as_t<basic_any<Len, Align>, Type> *>(data)->data()) : nullptr);
 }
 
 

--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -1549,7 +1549,7 @@ public:
      */
     template<typename Type>
     void unset() {
-        vars.erase(std::remove_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; }), vars.end());
+        vars.erase(std::remove_if(vars.begin(), vars.end(), [](auto &&var) { return var.template is<Type>(); }), vars.end());
     }
 
     /**
@@ -1577,14 +1577,14 @@ public:
      */
     template<typename Type>
     [[nodiscard]] std::add_const_t<Type> * try_ctx() const {
-        auto it = std::find_if(vars.cbegin(), vars.cend(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
+        auto it = std::find_if(vars.cbegin(), vars.cend(), [](auto &&var) { return var.template is<Type>(); });
         return it == vars.cend() ? nullptr : any_cast<std::add_const_t<Type>>(&*it);
     }
 
     /*! @copydoc try_ctx */
     template<typename Type>
     [[nodiscard]] Type * try_ctx() {
-        auto it = std::find_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
+        auto it = std::find_if(vars.begin(), vars.end(), [](auto &&var) { return var.template is<Type>(); });
         return it == vars.end() ? nullptr : any_cast<Type>(&*it);
     }
 
@@ -1600,7 +1600,7 @@ public:
      */
     template<typename Type>
     [[nodiscard]] std::add_const_t<Type> & ctx() const {
-        auto it = std::find_if(vars.cbegin(), vars.cend(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
+        auto it = std::find_if(vars.cbegin(), vars.cend(), [](auto &&var) { return var.template is<Type>(); });
         ENTT_ASSERT(it != vars.cend(), "Invalid instance");
         return any_cast<std::add_const_t<Type> &>(*it);
     }
@@ -1608,7 +1608,7 @@ public:
     /*! @copydoc ctx */
     template<typename Type>
     [[nodiscard]] Type & ctx() {
-        auto it = std::find_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
+        auto it = std::find_if(vars.begin(), vars.end(), [](auto &&var) { return var.template is<Type>(); });
         ENTT_ASSERT(it != vars.end(), "Invalid instance");
         return any_cast<Type &>(*it);
     }

--- a/test/entt/core/any.cpp
+++ b/test/entt/core/any.cpp
@@ -1161,3 +1161,11 @@ TEST_F(Any, DeducedArrayType) {
     ASSERT_EQ(any.type(), entt::type_id<const char *>());
     ASSERT_EQ((strcmp("another array of char", entt::any_cast<const char *>(any))), 0);
 }
+
+TEST_F(Any, IsType) {
+    entt::any any{"array of char"};
+
+    ASSERT_TRUE(any.is<const char*>());
+    ASSERT_FALSE(any.is<char*>());
+    ASSERT_FALSE(any.is<int>());
+}


### PR DESCRIPTION
See ramblings in https://github.com/skypjack/entt/issues/782 for motivation and more information.