### PR TITLE
Added user-defined context variable guard

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -69,6 +69,11 @@ static_assert(ENTT_PACKED_PAGE && ((ENTT_PACKED_PAGE & (ENTT_PACKED_PAGE - 1)) =
 #endif
 
 
+#ifndef ENTT_REGISTRY_CONTEXT_GUARD
+	#define ENTT_REGISTRY_CONTEXT_GUARD()
+#endif
+
+
 #ifndef ENTT_STANDARD_CPP
 #    if defined __clang__ || defined __GNUC__
 #       define ENTT_PRETTY_FUNCTION __PRETTY_FUNCTION__

--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -1596,6 +1596,7 @@ public:
     template<typename Type, typename... Args>
     Type & set(Args &&... args) {
         unset<Type>();
+        ENTT_REGISTRY_CONTEXT_GUARD()
         vars.emplace_back(std::in_place_type<Type>, std::forward<Args>(args)...);
         return any_cast<Type &>(vars.back());
     }
@@ -1606,6 +1607,7 @@ public:
      */
     template<typename Type>
     void unset() {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         vars.erase(std::remove_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; }), vars.end());
     }
 
@@ -1634,6 +1636,7 @@ public:
      */
     template<typename Type>
     [[nodiscard]] std::add_const_t<Type> * try_ctx() const {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         auto it = std::find_if(vars.cbegin(), vars.cend(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
         return it == vars.cend() ? nullptr : any_cast<std::add_const_t<Type>>(&*it);
     }
@@ -1641,6 +1644,7 @@ public:
     /*! @copydoc try_ctx */
     template<typename Type>
     [[nodiscard]] Type * try_ctx() {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         auto it = std::find_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
         return it == vars.end() ? nullptr : any_cast<Type>(&*it);
     }
@@ -1657,6 +1661,7 @@ public:
      */
     template<typename Type>
     [[nodiscard]] std::add_const_t<Type> & ctx() const {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         auto it = std::find_if(vars.cbegin(), vars.cend(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
         ENTT_ASSERT(it != vars.cend(), "Invalid instance");
         return any_cast<std::add_const_t<Type> &>(*it);
@@ -1665,6 +1670,7 @@ public:
     /*! @copydoc ctx */
     template<typename Type>
     [[nodiscard]] Type & ctx() {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         auto it = std::find_if(vars.begin(), vars.end(), [type = type_id<Type>()](auto &&var) { return var.type() == type; });
         ENTT_ASSERT(it != vars.end(), "Invalid instance");
         return any_cast<Type &>(*it);
@@ -1693,6 +1699,7 @@ public:
      */
     template<typename Func>
     void ctx(Func func) const {
+        ENTT_REGISTRY_CONTEXT_GUARD()
         for(auto pos = vars.size(); pos; --pos) {
             func(vars[pos-1].type());
         }


### PR DESCRIPTION
Fitting with the "don't pay for what you don't use" concept, I wanted to have an optional way of injecting some kind of lock/guard around context variables in the registry.

I let the user define how the lock is created since, for me, I use a fiber mutex rather than std::mutex, so I need to be able to define it myself. I'm using the lock in the 'leaf nodes' of the function calls since I can't support recursive mutexes and the end result is the same.

Addresses #799

(Let me know if you want a PR against another branch; maybe main?)