### PR TITLE
Store size information in hashed string 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ conan/test_package/build
 .idea
 .vscode
 .vs
+.cache
 CMakeSettings.json
 cpp.hint
 

--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -123,9 +123,7 @@ public:
     }
 
     /*! @brief Constructs an empty hashed string. */
-    constexpr basic_hashed_string() ENTT_NOEXCEPT
-        : str{nullptr},
-          hash{} {}
+    constexpr basic_hashed_string() ENTT_NOEXCEPT = default;
 
     /**
      * @brief Constructs a hashed string from an array of const characters.
@@ -189,8 +187,9 @@ public:
     }
 
 private:
-    const value_type *str;
-    hash_type hash;
+    const value_type *str = {};
+    hash_type hash{};
+    std::size_t size{};
 };
 
 /**

--- a/test/entt/core/hashed_string.cpp
+++ b/test/entt/core/hashed_string.cpp
@@ -68,6 +68,7 @@ TEST(HashedString, Empty) {
 
     ASSERT_EQ(static_cast<hash_type>(hs), hash_type{});
     ASSERT_EQ(static_cast<const char *>(hs), nullptr);
+    ASSERT_EQ(hs.size(), 0);
 }
 
 TEST(HashedString, Correctness) {
@@ -112,6 +113,8 @@ TEST(HashedString, Constexprness) {
 
     static_assert(entt::hashed_string{"foo"} > "bar"_hs);
     static_assert(entt::hashed_string{"foo"} >= "foo"_hs);
+
+    static_assert(entt::hashed_string{"my.png", 2} == "my"_hs);
 }
 
 TEST(HashedWString, Functionalities) {
@@ -138,7 +141,9 @@ TEST(HashedWString, Functionalities) {
     ASSERT_EQ(hws.value(), foobar_v);
 
     ASSERT_EQ(foo_hws, L"foo"_hws);
+    ASSERT_EQ(foo_hws, L"foo"_hs);
     ASSERT_NE(bar_hws, L"foo"_hws);
+    ASSERT_NE(bar_hws, L"foo"_hs);
 }
 
 TEST(HashedWString, Empty) {
@@ -148,6 +153,7 @@ TEST(HashedWString, Empty) {
 
     ASSERT_EQ(static_cast<hash_type>(hws), hash_type{});
     ASSERT_EQ(static_cast<const wchar_t *>(hws), nullptr);
+    ASSERT_EQ(hws.size(), 0);
 }
 
 TEST(HashedWString, Correctness) {
@@ -192,4 +198,6 @@ TEST(HashedWString, Constexprness) {
 
     static_assert(entt::hashed_wstring{L"foo"} > L"bar"_hws);
     static_assert(entt::hashed_wstring{L"foo"} >= L"foo"_hws);
+
+    static_assert(entt::hashed_wstring{L"my.png", 2} == L"my"_hws);
 }


### PR DESCRIPTION
This patch modifies hashed string to store the size of the given size, or calculate it if a c-string is given, which can be retrieved using the `.size()` member function.

This patch also adds an overload to the `_hs` string literal, allowing it to take a wide string literal and return hashed wide string.

An implicit conversion to `std::string_view` may also be desired, however this patch doesn't include this feature.