### PR TITLE
meta: reduced size of 3 node structures

### DIFF
--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -187,11 +187,11 @@ class meta_factory<Type> {
 
         static internal::meta_data_node node{
             {},
+            /* this is never static */
+            (std::is_member_object_pointer_v<decltype(value_list_element_v<Index, Setter>)> && ... && std::is_const_v<std::remove_reference_t<data_type>>) ? internal::meta_traits::is_const : internal::meta_traits::is_none,
             nullptr,
             nullptr,
             Setter::size,
-            /* this is never static */
-            (std::is_member_object_pointer_v<decltype(value_list_element_v<Index, Setter>)> && ... && std::is_const_v<std::remove_reference_t<data_type>>) ? internal::meta_traits::is_const : internal::meta_traits::is_none,
             internal::meta_node<std::remove_const_t<std::remove_reference_t<data_type>>>::resolve(),
             &meta_arg<type_list<type_list_element_t<type_list_element_t<Index, args_type>::size != 1u, type_list_element_t<Index, args_type>>...>>,
             [](meta_handle instance, meta_any value) -> bool { return (meta_setter<Type, value_list_element_v<Index, Setter>>(*instance.operator->(), value.as_ref()) || ...); },
@@ -412,11 +412,11 @@ public:
 
             static internal::meta_data_node node{
                 {},
+                /* this is never static */
+                std::is_const_v<data_type> ? internal::meta_traits::is_const : internal::meta_traits::is_none,
                 nullptr,
                 nullptr,
                 1u,
-                /* this is never static */
-                std::is_const_v<data_type> ? internal::meta_traits::is_const : internal::meta_traits::is_none,
                 internal::meta_node<std::remove_const_t<data_type>>::resolve(),
                 &meta_arg<type_list<std::remove_const_t<data_type>>>,
                 &meta_setter<Type, Data>,
@@ -431,10 +431,10 @@ public:
 
             static internal::meta_data_node node{
                 {},
+                ((std::is_same_v<Type, std::remove_const_t<data_type>> || std::is_const_v<data_type>) ? internal::meta_traits::is_const : internal::meta_traits::is_none) | internal::meta_traits::is_static,
                 nullptr,
                 nullptr,
                 1u,
-                ((std::is_same_v<Type, std::remove_const_t<data_type>> || std::is_const_v<data_type>) ? internal::meta_traits::is_const : internal::meta_traits::is_none) | internal::meta_traits::is_static,
                 internal::meta_node<std::remove_const_t<data_type>>::resolve(),
                 &meta_arg<type_list<std::remove_const_t<data_type>>>,
                 &meta_setter<Type, Data>,
@@ -475,11 +475,11 @@ public:
         if constexpr(std::is_same_v<decltype(Setter), std::nullptr_t>) {
             static internal::meta_data_node node{
                 {},
+                /* this is never static */
+                internal::meta_traits::is_const,
                 nullptr,
                 nullptr,
                 0u,
-                /* this is never static */
-                internal::meta_traits::is_const,
                 internal::meta_node<std::remove_const_t<std::remove_reference_t<data_type>>>::resolve(),
                 &meta_arg<type_list<>>,
                 &meta_setter<Type, Setter>,
@@ -494,11 +494,11 @@ public:
 
             static internal::meta_data_node node{
                 {},
+                /* this is never static nor const */
+                internal::meta_traits::is_none,
                 nullptr,
                 nullptr,
                 1u,
-                /* this is never static nor const */
-                internal::meta_traits::is_none,
                 internal::meta_node<std::remove_const_t<std::remove_reference_t<data_type>>>::resolve(),
                 &meta_arg<type_list<type_list_element_t<args_type::size != 1u, args_type>>>,
                 &meta_setter<Type, Setter>,
@@ -553,10 +553,10 @@ public:
 
         static internal::meta_func_node node{
             {},
+            (descriptor::is_const ? internal::meta_traits::is_const : internal::meta_traits::is_none) | (descriptor::is_static ? internal::meta_traits::is_static : internal::meta_traits::is_none),
             nullptr,
             nullptr,
             descriptor::args_type::size,
-            (descriptor::is_const ? internal::meta_traits::is_const : internal::meta_traits::is_none) | (descriptor::is_static ? internal::meta_traits::is_static : internal::meta_traits::is_none),
             internal::meta_node<std::conditional_t<std::is_same_v<Policy, as_void_t>, void, std::remove_const_t<std::remove_reference_t<typename descriptor::return_type>>>>::resolve(),
             &meta_arg<typename descriptor::args_type>,
             &meta_invoke<Type, Candidate, Policy>

--- a/src/entt/meta/node.hpp
+++ b/src/entt/meta/node.hpp
@@ -71,10 +71,10 @@ struct meta_ctor_node {
 struct meta_data_node {
     using size_type = std::size_t;
     id_type id;
+    const meta_traits traits;
     meta_data_node *next;
     meta_prop_node *prop;
     const size_type arity;
-    const meta_traits traits;
     meta_type_node *const type;
     meta_type (*const arg)(const size_type) ENTT_NOEXCEPT;
     bool (*const set)(meta_handle, meta_any);
@@ -84,10 +84,10 @@ struct meta_data_node {
 struct meta_func_node {
     using size_type = std::size_t;
     id_type id;
+    const meta_traits traits;
     meta_func_node *next;
     meta_prop_node *prop;
     const size_type arity;
-    const meta_traits traits;
     meta_type_node *const ret;
     meta_type (*const arg)(const size_type) ENTT_NOEXCEPT;
     meta_any (*const invoke)(meta_handle, meta_any *const);
@@ -104,10 +104,10 @@ struct meta_type_node {
     using size_type = std::size_t;
     const type_info *info;
     id_type id;
+    const meta_traits traits;
     meta_type_node *next;
     meta_prop_node *prop;
     const size_type size_of;
-    const meta_traits traits;
     meta_any (*const default_constructor)();
     double (*const conversion_helper)(void *, const void *);
     const meta_template_node *const templ;
@@ -168,9 +168,6 @@ public:
         static meta_type_node node{
             &type_id<Type>(),
             {},
-            nullptr,
-            nullptr,
-            size_of_v<Type>,
             internal::meta_traits::is_none
                 | (std::is_arithmetic_v<Type> ? internal::meta_traits::is_arithmetic : internal::meta_traits::is_none)
                 | (std::is_array_v<Type> ? internal::meta_traits::is_array : internal::meta_traits::is_none)
@@ -180,6 +177,9 @@ public:
                 | (is_meta_pointer_like_v<Type> ? internal::meta_traits::is_meta_pointer_like : internal::meta_traits::is_none)
                 | (is_complete_v<meta_sequence_container_traits<Type>> ? internal::meta_traits::is_meta_sequence_container : internal::meta_traits::is_none)
                 | (is_complete_v<meta_associative_container_traits<Type>> ? internal::meta_traits::is_meta_associative_container : internal::meta_traits::is_none),
+            nullptr,
+            nullptr,
+            size_of_v<Type>,
             meta_default_constructor(),
             meta_conversion_helper(),
             meta_template_info()


### PR DESCRIPTION
These changes reduce, under some quite common circumstances (like `id_type` and `meta_traits` being 4 bytes under an x64 system), the size of `meta_data_node`, `meta_func_node` and `meta_type_node` by 4 bytes each.