### PR TITLE
Overflow of version and max number of entities

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ ceeac
 ColinH
 corystegel
 Croydon
+cschreib
 cugone
 dbacchet
 dBagrat

--- a/TODO
+++ b/TODO
@@ -18,6 +18,7 @@ WIP:
 * entity-only and exclude-only views
 * custom allocators all over
 * use ENTT_NOEXCEPT_IF as appropriate (ie make compressed_pair conditionally noexcept)
+* add test for maximum number of entities reached
 
 WIP:
 * add user data to type_info

--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -301,7 +301,7 @@ class basic_registry {
     }
 
     auto generate_identifier(const std::size_t pos) ENTT_NOEXCEPT {
-        ENTT_ASSERT(pos < entity_traits::to_integral(null), "No entities available");
+        ENTT_ASSERT(pos < entity_traits::to_entity(null), "No entities available");
         return entity_traits::combine(static_cast<typename entity_traits::entity_type>(pos), {});
     }
 


### PR DESCRIPTION
This is a draft PR, since it contains changes that I think would be good to merge, but also other changes that are more explorative at this stage. I have been trying to understand the behavior of EnTT when it comes to reaching the limits of the registry: too many entities, or too many cycles of create/release (overflow of version).

 1. I think I have found an issue in `basic_registry::generate_identifier`, which can return values that cannot be represented in the entity mask, resulting in very odd behavior. I fixed this and added a test.
 2. Trying to understand the logic of version overflow, I added a more extensive test that checks overflow for all entity values. I was surprised by the behavior. First, the registry will prefer to overflow even if there are free entity slots available; I think overflow should be prevented as much as possible. Second, the behavior of overflow depends on which entity is overflowing: in particular, the "last" entity (maximum value of the entity mask) will generate an error on overflow, while the others will overflow silently. I wonder if this is expected. I added the test that shows this, `VersionOverflowAll`, which currently fails on the last iteration of `i`.
