### PR TITLE
[User Story AB#891328] Separate entt assert for constexpr functions (defaults to same)

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -38,9 +38,11 @@
 #ifdef ENTT_DISABLE_ASSERT
 #    undef ENTT_ASSERT
 #    define ENTT_ASSERT(...) (void(0))
+#    define ENTT_CONSTEXPR_ASSERT(...) (void(0))
 #elif !defined ENTT_ASSERT
 #    include <cassert>
 #    define ENTT_ASSERT(condition, ...) assert(condition)
+#    define ENTT_CONSTEXPR_ASSERT(condition, ...) assert(condition)
 #endif
 
 #ifdef ENTT_NO_ETO

--- a/src/entt/core/memory.hpp
+++ b/src/entt/core/memory.hpp
@@ -60,7 +60,7 @@ constexpr void propagate_on_container_move_assignment([[maybe_unused]] Allocator
  */
 template<typename Allocator>
 constexpr void propagate_on_container_swap([[maybe_unused]] Allocator &lhs, [[maybe_unused]] Allocator &rhs) noexcept {
-    ENTT_ASSERT(std::allocator_traits<Allocator>::propagate_on_container_swap::value || lhs == rhs, "Cannot swap the containers");
+    ENTT_CONSTEXPR_ASSERT(std::allocator_traits<Allocator>::propagate_on_container_swap::value || lhs == rhs, "Cannot swap the containers");
 
     if constexpr(std::allocator_traits<Allocator>::propagate_on_container_swap::value) {
         using std::swap;
@@ -83,7 +83,7 @@ constexpr void propagate_on_container_swap([[maybe_unused]] Allocator &lhs, [[ma
  * @return The smallest power of two greater than or equal to the given value.
  */
 [[nodiscard]] inline constexpr std::size_t next_power_of_two(const std::size_t value) noexcept {
-    ENTT_ASSERT(value < (std::size_t{1u} << (std::numeric_limits<std::size_t>::digits - 1)), "Numeric limits exceeded");
+    ENTT_CONSTEXPR_ASSERT(value < (std::size_t{1u} << (std::numeric_limits<std::size_t>::digits - 1)), "Numeric limits exceeded");
     std::size_t curr = value - (value != 0u);
 
     for(int next = 1; next < std::numeric_limits<std::size_t>::digits; next = next * 2) {
@@ -100,7 +100,7 @@ constexpr void propagate_on_container_swap([[maybe_unused]] Allocator &lhs, [[ma
  * @return The common remainder.
  */
 [[nodiscard]] inline constexpr std::size_t fast_mod(const std::size_t value, const std::size_t mod) noexcept {
-    ENTT_ASSERT(is_power_of_two(mod), "Value must be a power of two");
+    ENTT_CONSTEXPR_ASSERT(is_power_of_two(mod), "Value must be a power of two");
     return value & (mod - 1u);
 }
 


### PR DESCRIPTION
So that we can define a separate constexpr assert handler vs regular.
Unfortunately we can't use std::is_constant_evaluated (c++20, also doesn't work with the static), the only solution other than splitting the assert is c++23's consteval and that isn't happening so here we are!

Summary:
Want to define a static bool inside our assert handler, but that breaks all constexpr usages of the assert. Plan is to define a constexpr friendly one and the new non constexpr friendly one (using the static, that lets you ignore the assert via dialog).
To do so requires us to use a separate assert for these cases (such as these ones here in entt, which actually were the only cases in the codebase where the assert was used in a constexpr function).