### PR TITLE
Add Vcpkg badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/skypjack/entt/workflows/build/badge.svg)](https://github.com/skypjack/entt/actions)
 [![Coverage](https://codecov.io/gh/skypjack/entt/branch/master/graph/badge.svg)](https://codecov.io/gh/skypjack/entt)
 [![Try online](https://img.shields.io/badge/try-online-brightgreen)](https://godbolt.org/z/zxW73f)
+[![Vcpkg port](https://img.shields.io/vcpkg/v/entt)](https://vcpkg.link/ports/entt)
 [![Documentation](https://img.shields.io/badge/docs-doxygen-blue)](https://skypjack.github.io/entt/)
 [![Gitter chat](https://badges.gitter.im/skypjack/entt.png)](https://gitter.im/skypjack/entt)
 [![Discord channel](https://img.shields.io/discord/707607951396962417?logo=discord)](https://discord.gg/5BjPWBd)


### PR DESCRIPTION
I'm the author of [vcpkg.link](https://vcpkg.link) and currently trying to improve the discoverability of Vcpkg ports since it helps other developers to integrate libraries into their projects.

This PR aims to add a fresh new [shields.io](https://shields.io) badge (https://github.com/badges/shields/pull/8923) that provides at a glance in the README which version of EnTT is available on [Vcpkg](https://vcpkg.link/ports/entt).

![Vcpkg Shields.io Badge](https://img.shields.io/vcpkg/v/entt)