### PR TITLE
Fixed undefined behavior with sigh publish loop

### DIFF
--- a/src/entt/signal/sigh.hpp
+++ b/src/entt/signal/sigh.hpp
@@ -168,8 +168,8 @@ public:
      * @param args Arguments to use to invoke listeners.
      */
     void publish(Args... args) const {
-        for(int i=0; i<calls.size(); i++) {
-            auto&& call = calls[i];
+        container_type callsCopy = calls; // Copy allows for calls to be changed inside of the loop without causing any undefined behavior
+        for (auto &&call: callsCopy) {
             call(args...);
         }
     }

--- a/src/entt/signal/sigh.hpp
+++ b/src/entt/signal/sigh.hpp
@@ -168,7 +168,8 @@ public:
      * @param args Arguments to use to invoke listeners.
      */
     void publish(Args... args) const {
-        for(auto &&call: std::as_const(calls)) {
+        for(int i=0; i<calls.size(); i++) {
+            auto&& call = calls[i];
             call(args...);
         }
     }


### PR DESCRIPTION
It appears that on clang, if you modify calls (i.e. by releasing a connection) from within the scope of the **ranged-based for loop** referencing _calls_, you will get a "vector iterator past end" error.

No error seems to manifest itself on MSVC.

I have changed the **ranged-based for loop** in publish to a **regular for loop**. I have also added a test to check if there is an issue with a disconnect from inside of the loop scope.

This change was not made without cause, as I was experiencing an issue in my project where I had Lua code that disconnected from a signal inside of the callback body of the signal. This code was being run inside of the for loop's body, resulting in a "vector iterator past end" error. This change is necessary to fix my system. I have put a hotfix in but it does not work for my other developers who pull down the project.