### PR TITLE
Implement support for dynamic sized storages

### DIFF
--- a/src/entt/entity/mixin.hpp
+++ b/src/entt/entity/mixin.hpp
@@ -77,6 +77,8 @@ class sigh_mixin final: public Type {
 public:
     /*! @brief Allocator type. */
     using allocator_type = typename Type::allocator_type;
+    /*! @brief Component traits. */
+    using traits_type = typename Type::traits_type;
     /*! @brief Underlying entity identifier. */
     using entity_type = typename Type::entity_type;
     /*! @brief Expected registry type. */
@@ -89,9 +91,10 @@ public:
     /**
      * @brief Constructs an empty storage with a given allocator.
      * @param allocator The allocator to use.
+     * @param traits The type_traits to use.
      */
-    explicit sigh_mixin(const allocator_type &allocator)
-        : Type{allocator},
+    explicit sigh_mixin(const allocator_type &allocator, traits_type traits = {})
+        : Type{allocator, std::move(traits)},
           owner{},
           construction{allocator},
           destruction{allocator},

--- a/test/entt/entity/sigh_mixin.cpp
+++ b/test/entt/entity/sigh_mixin.cpp
@@ -35,7 +35,7 @@ struct empty_each_tag final {};
 
 template<>
 struct entt::basic_storage<empty_each_tag, entt::entity, std::allocator<empty_each_tag>>: entt::basic_storage<void, entt::entity, std::allocator<void>> {
-    basic_storage(const std::allocator<empty_each_tag> &) {}
+    using basic_storage<void, entt::entity, std::allocator<void>>::basic_storage;
 
     [[nodiscard]] iterable each() noexcept {
         return {internal::extended_storage_iterator{base_type::end()}, internal::extended_storage_iterator{base_type::end()}};


### PR DESCRIPTION
Hi @skypjack,

as discussed in Discord I'm proposing the following code to add dynamic (runtime) sized object support to entt.

I'm looking forward to your feedback.

---

## Points to discuss

There is also the possibility to move the methods from the traits objects into the stateful allocator, but I thought it would be much cleaner to keep the responsibility of the allocator and the storage related methods separate.

## ToDo

- [ ] Implement missing tests
- [ ] Review whether it is intended that `move_element` can alias (the element to swap from and to can point to the same object by the storage algorithms): e.g. `[[maybe_unused]] auto unused = std::exchange(elem, std::move(other));` in `basic_storage::pop`.
- [ ] Review the polymorphic allocator workaround
- [x] Discuss heavily copying of allocators in the storage class (before this PR), those should be passed as lvalue reference. Would be the possibility for a follow-up commit.

---

## Usage

```cpp
entt::registry registry;

    // Create a dynamic trait object
    entt::component_traits<dynamic_data> const traits(32);
    ASSERT_EQ(traits.dynamic_size(), 32);

    // Create an allocator which supplies objects of the dynamic size
    dynamic_allocator<dynamic_data> const alloc{traits.dynamic_size()};

    // Create the storage for the dynamic sized data,
    // and assert that it was created with the specified parameters.
    ASSERT_TRUE(registry.try_create_storage<dynamic_data>(alloc, traits));

    auto &storage = registry.storage<dynamic_data>();

    // Ensure that the allocator matches the provided one
    ASSERT_EQ(storage.get_allocator(), alloc);

    // Ensure that the trait matches the provided one
    ASSERT_EQ(storage.get_traits(), traits);

    entt::entity const e1 = registry.create();
    entt::entity const e2 = registry.create();

    {
        dynamic_data &d1 = registry.emplace<dynamic_data>(e1);
        dynamic_data &d2 = registry.emplace<dynamic_data>(e2);
```