### PR TITLE
``std::tuple`` trait specializations for ``entt::type_list`` and ``entt::value_list``

### DIFF
--- a/src/entt/core/tuple.hpp
+++ b/src/entt/core/tuple.hpp
@@ -110,4 +110,7 @@ struct std::tuple_element<Index, entt::type_list<Type...>>: entt::type_list_elem
 template <auto... Value>
 struct std::tuple_size<entt::value_list<Value...>>: std::integral_constant<std::size_t, entt::value_list<Value...>::size> {};
 
+template <std::size_t Index, auto... Value>
+struct std::tuple_element<Index, entt::value_list<Value...>>: entt::value_list_element<Index, entt::value_list<Value...>> {};
+
 #endif

--- a/src/entt/core/tuple.hpp
+++ b/src/entt/core/tuple.hpp
@@ -107,4 +107,7 @@ struct std::tuple_size<entt::type_list<Type...>>: std::integral_constant<std::si
 template <std::size_t Index, typename... Type>
 struct std::tuple_element<Index, entt::type_list<Type...>>: entt::type_list_element<Index, entt::type_list<Type...>> {};
 
+template <auto... Value>
+struct std::tuple_size<entt::value_list<Value...>>: std::integral_constant<std::size_t, entt::value_list<Value...>::size> {};
+
 #endif

--- a/src/entt/core/tuple.hpp
+++ b/src/entt/core/tuple.hpp
@@ -4,6 +4,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include "type_traits.hpp"
 
 namespace entt {
 
@@ -99,5 +100,8 @@ template<typename Func>
 forward_apply(Func) -> forward_apply<std::remove_reference_t<std::remove_cv_t<Func>>>;
 
 } // namespace entt
+
+template <typename... Type>
+struct std::tuple_size<entt::type_list<Type...>>: std::integral_constant<std::size_t,  entt::type_list<Type...>::size> {};
 
 #endif

--- a/src/entt/core/tuple.hpp
+++ b/src/entt/core/tuple.hpp
@@ -102,6 +102,9 @@ forward_apply(Func) -> forward_apply<std::remove_reference_t<std::remove_cv_t<Fu
 } // namespace entt
 
 template <typename... Type>
-struct std::tuple_size<entt::type_list<Type...>>: std::integral_constant<std::size_t,  entt::type_list<Type...>::size> {};
+struct std::tuple_size<entt::type_list<Type...>>: std::integral_constant<std::size_t, entt::type_list<Type...>::size> {};
+
+template <std::size_t Index, typename... Type>
+struct std::tuple_element<Index, entt::type_list<Type...>>: entt::type_list_element<Index, entt::type_list<Type...>> {};
 
 #endif

--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -387,7 +387,18 @@ template<auto Value, auto... Other>
 struct value_list_element<0u, value_list<Value, Other...>> {
     /*! @brief Searched value. */
     static constexpr auto value = Value;
+
+    /*! @brief Searched type. */
+    using type = decltype(Value);
 };
+
+/**
+ * @brief Helper type.
+ * @tparam Index Index of the type to return.
+ * @tparam List Value list to search into.
+ */
+template<std::size_t Index, typename List>
+using value_list_element_t = typename value_list_element<Index, List>::type;
 
 /**
  * @brief Helper type.

--- a/src/entt/core/type_traits.hpp
+++ b/src/entt/core/type_traits.hpp
@@ -335,13 +335,14 @@ struct type_list_transform;
 
 /**
  * @brief Applies a given _function_ to a type list and generate a new list.
+ * @tparam Container Template type containing types.
  * @tparam Type Types provided by the type list.
  * @tparam Op Unary operation as template class with a type member named `type`.
  */
-template<typename... Type, template<typename...> class Op>
-struct type_list_transform<type_list<Type...>, Op> {
+template<template<typename...> class Container, typename... Type, template<typename...> class Op>
+struct type_list_transform<Container<Type...>, Op> {
     /*! @brief Resulting type list after applying the transform function. */
-    using type = type_list<typename Op<Type>::type...>;
+    using type = Container<typename Op<Type>::type...>;
 };
 
 /**

--- a/src/entt/entity/fwd.hpp
+++ b/src/entt/entity/fwd.hpp
@@ -148,39 +148,6 @@ struct owned_t final: type_list<Type...> {
 template<typename... Type>
 inline constexpr owned_t<Type...> owned{};
 
-/**
- * @brief Applies a given _function_ to a get list and generate a new list.
- * @tparam Type Types provided by the get list.
- * @tparam Op Unary operation as template class with a type member named `type`.
- */
-template<typename... Type, template<typename...> class Op>
-struct type_list_transform<get_t<Type...>, Op> {
-    /*! @brief Resulting get list after applying the transform function. */
-    using type = get_t<typename Op<Type>::type...>;
-};
-
-/**
- * @brief Applies a given _function_ to an exclude list and generate a new list.
- * @tparam Type Types provided by the exclude list.
- * @tparam Op Unary operation as template class with a type member named `type`.
- */
-template<typename... Type, template<typename...> class Op>
-struct type_list_transform<exclude_t<Type...>, Op> {
-    /*! @brief Resulting exclude list after applying the transform function. */
-    using type = exclude_t<typename Op<Type>::type...>;
-};
-
-/**
- * @brief Applies a given _function_ to an owned list and generate a new list.
- * @tparam Type Types provided by the owned list.
- * @tparam Op Unary operation as template class with a type member named `type`.
- */
-template<typename... Type, template<typename...> class Op>
-struct type_list_transform<owned_t<Type...>, Op> {
-    /*! @brief Resulting owned list after applying the transform function. */
-    using type = owned_t<typename Op<Type>::type...>;
-};
-
 /*! @brief Alias declaration for the most common use case. */
 using sparse_set = basic_sparse_set<>;
 

--- a/test/entt/core/tuple.cpp
+++ b/test/entt/core/tuple.cpp
@@ -54,3 +54,9 @@ TEST(ValueList, TupleSize) {
     ASSERT_EQ(std::tuple_size_v<entt::value_list<42>>, 1u);
     ASSERT_EQ((std::tuple_size_v<entt::value_list<42, 'a'>>), 2u);
 }
+
+TEST(ValueList, TupleElement) {
+    ASSERT_TRUE((std::is_same_v<int, std::tuple_element_t<0, entt::value_list<42>>>));
+    ASSERT_TRUE((std::is_same_v<int, std::tuple_element_t<0, entt::value_list<42, 'a'>>>));
+    ASSERT_TRUE((std::is_same_v<char, std::tuple_element_t<1, entt::value_list<42, 'a'>>>));
+}

--- a/test/entt/core/tuple.cpp
+++ b/test/entt/core/tuple.cpp
@@ -48,3 +48,9 @@ TEST(TypeList, TupleElement) {
     ASSERT_TRUE((std::is_same_v<int, std::tuple_element_t<0, entt::type_list<int, float>>>));
     ASSERT_TRUE((std::is_same_v<float, std::tuple_element_t<1, entt::type_list<int, float>>>));
 }
+
+TEST(ValueList, TupleSize) {
+    ASSERT_EQ(std::tuple_size_v<entt::value_list<>>, 0u);
+    ASSERT_EQ(std::tuple_size_v<entt::value_list<42>>, 1u);
+    ASSERT_EQ((std::tuple_size_v<entt::value_list<42, 'a'>>), 2u);
+}

--- a/test/entt/core/tuple.cpp
+++ b/test/entt/core/tuple.cpp
@@ -36,3 +36,9 @@ TEST(Tuple, ForwardApply) {
     ASSERT_EQ(entt::forward_apply{[](int i) { return i; }}(std::make_tuple(42)), 42);
     ASSERT_EQ(entt::forward_apply{[](auto... args) { return (args + ...); }}(std::make_tuple('a', 1)), 'b');
 }
+
+TEST(TypeList, TupleSize) {
+    ASSERT_EQ(std::tuple_size_v<entt::type_list<>>, 0u);
+    ASSERT_EQ(std::tuple_size_v<entt::type_list<int>>, 1u);
+    ASSERT_EQ((std::tuple_size_v<entt::type_list<int, float>>), 2u);
+}

--- a/test/entt/core/tuple.cpp
+++ b/test/entt/core/tuple.cpp
@@ -42,3 +42,9 @@ TEST(TypeList, TupleSize) {
     ASSERT_EQ(std::tuple_size_v<entt::type_list<int>>, 1u);
     ASSERT_EQ((std::tuple_size_v<entt::type_list<int, float>>), 2u);
 }
+
+TEST(TypeList, TupleElement) {
+    ASSERT_TRUE((std::is_same_v<int, std::tuple_element_t<0, entt::type_list<int>>>));
+    ASSERT_TRUE((std::is_same_v<int, std::tuple_element_t<0, entt::type_list<int, float>>>));
+    ASSERT_TRUE((std::is_same_v<float, std::tuple_element_t<1, entt::type_list<int, float>>>));
+}


### PR DESCRIPTION
As discussed on the discord, I would like to specialize these common traits for the entt types.

As a second minor improvement, I unified your specializations of ``type_list_transform`` into one specialization. If you don't like it, I'll revert that change.

Hopefully these changes match your style-guide. Resharper doesn't seem to recognize the clang-format correctly.