### PR TITLE
dense_*: workaround for the max() ambiguity with MAX macro.

### DIFF
--- a/src/entt/container/dense_map.hpp
+++ b/src/entt/container/dense_map.hpp
@@ -989,7 +989,7 @@ public:
             sparse.first().resize(sz);
 
             for(auto &&elem: sparse.first()) {
-                elem = std::numeric_limits<size_type>::max();
+                elem = (std::numeric_limits<size_type>::max)();
             }
 
             for(size_type pos{}, last = size(); pos < last; ++pos) {

--- a/src/entt/container/dense_set.hpp
+++ b/src/entt/container/dense_set.hpp
@@ -842,7 +842,7 @@ public:
             sparse.first().resize(sz);
 
             for(auto &&elem: sparse.first()) {
-                elem = std::numeric_limits<size_type>::max();
+                elem = (std::numeric_limits<size_type>::max)();
             }
 
             for(size_type pos{}, last = size(); pos < last; ++pos) {


### PR DESCRIPTION
There is ambiguity between std::max() and MAX macro, which propagates via "Windows.h", on the Windows platform. In order not to bother the user with the NOMINMAX definitions, the bracketing method was chosen.