### PR TITLE
Fix C++20 global module fragment inclusion

### DIFF
--- a/src/entt/core/type_info.hpp
+++ b/src/entt/core/type_info.hpp
@@ -44,7 +44,7 @@ template<typename Type, auto = stripped_type_name<Type>().find_first_of('.')>
 }
 
 template<typename Type>
-[[nodiscard]] inline std::string_view type_name(char) noexcept {
+[[nodiscard]] std::string_view type_name(char) noexcept {
     static const auto value = stripped_type_name<Type>();
     return value;
 }
@@ -57,7 +57,7 @@ template<typename Type, auto = stripped_type_name<Type>().find_first_of('.')>
 }
 
 template<typename Type>
-[[nodiscard]] inline id_type type_hash(char) noexcept {
+[[nodiscard]] id_type type_hash(char) noexcept {
     static const auto value = [](const auto stripped) {
         return hashed_string::value(stripped.data(), stripped.size());
     }(stripped_type_name<Type>());

--- a/src/entt/core/type_info.hpp
+++ b/src/entt/core/type_info.hpp
@@ -38,26 +38,26 @@ template<typename Type>
 }
 
 template<typename Type, auto = stripped_type_name<Type>().find_first_of('.')>
-[[nodiscard]] static constexpr std::string_view type_name(int) noexcept {
+[[nodiscard]] constexpr std::string_view type_name(int) noexcept {
     constexpr auto value = stripped_type_name<Type>();
     return value;
 }
 
 template<typename Type>
-[[nodiscard]] static std::string_view type_name(char) noexcept {
+[[nodiscard]] inline std::string_view type_name(char) noexcept {
     static const auto value = stripped_type_name<Type>();
     return value;
 }
 
 template<typename Type, auto = stripped_type_name<Type>().find_first_of('.')>
-[[nodiscard]] static constexpr id_type type_hash(int) noexcept {
+[[nodiscard]] constexpr id_type type_hash(int) noexcept {
     constexpr auto stripped = stripped_type_name<Type>();
     constexpr auto value = hashed_string::value(stripped.data(), stripped.size());
     return value;
 }
 
 template<typename Type>
-[[nodiscard]] static id_type type_hash(char) noexcept {
+[[nodiscard]] inline id_type type_hash(char) noexcept {
     static const auto value = [](const auto stripped) {
         return hashed_string::value(stripped.data(), stripped.size());
     }(stripped_type_name<Type>());

--- a/src/entt/entity/entity.hpp
+++ b/src/entt/entity/entity.hpp
@@ -18,7 +18,7 @@ namespace internal {
 
 // waiting for C++20 (and std::popcount)
 template<typename Type>
-static constexpr int popcount(Type value) noexcept {
+constexpr int popcount(Type value) noexcept {
     return value ? (int(value & 1) + popcount(value >> 1)) : 0;
 }
 


### PR DESCRIPTION
Using the experimental C++20 modules support in recent builds of Clang, EnTT currently causes compilation errors when included as part of the global module fragment in a module interface unit that exports part of EnTT's API and is then imported and used by a different translation unit. Here is a minimal example (note the "error: no matching function for call to 'popcount'" in the output): https://godbolt.org/z/9vTjz9Prh

The reason seems to be that certain function declarations that are implicitly required by the implementation aren't exported into the module interface since they are erroneously marked 'static' and have internal linkage when they should (presumably) be 'inline'. I found that changing these declarations accordingly fixed the problem and made EnTT work well with C++20 modules in my project, and this PR reflects those changes.

Unfortunately I can't write proper test cases for this since it depends on features that are still experimental in most compilers, so there may still be other static declarations that I have missed that could cause problems in other modules-based projects, but as long as these changes don't break anything for regular non-modules builds, they should hopefully at least help make EnTT a bit more modules-friendly in the short term.