### PR TITLE
Docs - Fix typo in Sorting section

### DIFF
--- a/docs/md/entity.md
+++ b/docs/md/entity.md
@@ -583,7 +583,7 @@ There are two functions that respond to slightly different needs:
 * Components are sorted either directly:
 
   ```cpp
-  registry.sort<renderable>([](const auto &lhs, const auto &rhs) {
+  registry.sort<renderable>([](const renderable &lhs, const renderable &rhs) {
       return lhs.z < rhs.z;
   });
   ```


### PR DESCRIPTION
Using `const auto &...`  for the arguments doesn't work because the `entt::entity` overload has priority over the component (in this case, `renderable`) overload.

https://github.com/skypjack/entt/issues/535#issuecomment-667853342