### PR TITLE
Fixes documentation generation bug

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Doxygen configuration (documentation)
 
+include(FetchContent)
+
 FetchContent_Declare(
     doxygen-awesome-css
     GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css


### PR DESCRIPTION
Building only the documentation without enabling testing (i.e. without setting `ENTT_BUILD_TESTING=ON`) failed. The bug occurred because `FetchContent` wasn't included in `docs/CMakeLists.txt`. However it was included in `test/CMakeLists.txt`, which explains why the bug wasn't triggered when testing was enabled.

Note that this bug is also present in the latest release (v3.12.2).