### PR TITLE
Print assertion message upon failure

### DIFF
--- a/src/entt/config/config.h
+++ b/src/entt/config/config.h
@@ -44,7 +44,7 @@
 #    define ENTT_ASSERT(condition, msg) (void(0))
 #elif !defined ENTT_ASSERT
 #    include <cassert>
-#    define ENTT_ASSERT(condition, msg) assert(condition)
+#    define ENTT_ASSERT(condition, msg) assert(condition && msg)
 #endif
 
 #ifdef ENTT_DISABLE_ASSERT


### PR DESCRIPTION
Closes #1163 

Before:
```
Assertion failed: (contains(entt)), function index, file sparse_set.hpp, line 717.
/bin/sh: line 1: 96048 Abort trap: 6
```

After:
```
Assertion failed: (contains(entt) && "Set does not contain entity"), function index, file sparse_set.hpp, line 717.
/bin/sh: line 1: 96499 Abort trap: 6
```