### PR TITLE
Automatic signal registration for components

### DIFF
--- a/src/entt/entity/mixin.hpp
+++ b/src/entt/entity/mixin.hpp
@@ -14,30 +14,30 @@ namespace entt {
 /*! @cond TURN_OFF_DOXYGEN */
 namespace internal {
 
-template <typename T, typename Reg, typename = void>
-struct has_on_construct final : std::false_type {};
+template<typename T, typename Reg, typename = void>
+struct has_on_construct final: std::false_type {};
 
-template <typename T, typename Reg>
+template<typename T, typename Reg>
 struct has_on_construct<
     T, Reg,
     std::void_t<decltype(T::on_construct(std::declval<Reg &>(),
                                          std::declval<Reg &>().create()))>>
     : std::true_type {};
 
-template <typename T, typename Reg, typename = void>
-struct has_on_update final : std::false_type {};
+template<typename T, typename Reg, typename = void>
+struct has_on_update final: std::false_type {};
 
-template <typename T, typename Reg>
+template<typename T, typename Reg>
 struct has_on_update<
     T, Reg,
     std::void_t<decltype(T::on_update(std::declval<Reg &>(),
                                       std::declval<Reg &>().create()))>>
     : std::true_type {};
 
-template <typename T, typename Reg, typename = void>
-struct has_on_destroy final : std::false_type {};
+template<typename T, typename Reg, typename = void>
+struct has_on_destroy final: std::false_type {};
 
-template <typename T, typename Reg>
+template<typename T, typename Reg>
 struct has_on_destroy<
     T, Reg,
     std::void_t<decltype(T::on_destroy(std::declval<Reg &>(),
@@ -144,19 +144,18 @@ public:
           owner{},
           construction{allocator},
           destruction{allocator},
-          update{allocator}
-    {
+          update{allocator} {
         using element_type = typename Type::element_type;
 
-        if constexpr (internal::has_on_construct<element_type, Registry>::value) {
+        if constexpr(internal::has_on_construct<element_type, Registry>::value) {
             entt::sink{construction}.template connect<&element_type::on_construct>();
         }
 
-        if constexpr (internal::has_on_update<element_type, Registry>::value) {
+        if constexpr(internal::has_on_update<element_type, Registry>::value) {
             entt::sink{update}.template connect<&element_type::on_update>();
         }
 
-        if constexpr (internal::has_on_destroy<element_type, Registry>::value) {
+        if constexpr(internal::has_on_destroy<element_type, Registry>::value) {
             entt::sink{destruction}.template connect<&element_type::on_destroy>();
         }
     }

--- a/test/entt/entity/storage_signals.cpp
+++ b/test/entt/entity/storage_signals.cpp
@@ -1,0 +1,64 @@
+
+#include <gtest/gtest.h>
+#include <entt/entity/registry.hpp>
+
+struct count_tracker final {
+    inline static void on_construct(entt::registry &, entt::entity) {
+        ++created;
+    }
+
+    inline static void on_update(entt::registry &, entt::entity) {
+        ++updated;
+    }
+
+    inline static void on_destroy(entt::registry &, entt::entity) {
+        ++destroyed;
+    }
+
+    inline static std::size_t created = 0;
+    inline static std::size_t updated = 0;
+    inline static std::size_t destroyed = 0;
+    
+    inline static std::size_t alive() {
+        return created - destroyed;
+    }
+};
+
+template <typename Type>
+struct StorageSignals: testing::Test {
+    using type = Type;
+};
+
+using StorageSignalsTypes = ::testing::Types<count_tracker>;
+
+TYPED_TEST_SUITE(StorageSignals, StorageSignalsTypes, );
+
+TYPED_TEST(StorageSignals, AutoSignals) {
+    using value_type = typename TestFixture::type;
+
+    entt::registry registry;
+    auto const id = registry.create();
+
+    registry.emplace<count_tracker>(id);
+
+    ASSERT_EQ(count_tracker::created, 1);
+    ASSERT_EQ(count_tracker::updated, 0);
+    ASSERT_EQ(count_tracker::destroyed, 0);
+    ASSERT_EQ(count_tracker::alive(), 1);
+
+    registry.replace<count_tracker>(id);
+
+    ASSERT_EQ(count_tracker::created, 1);
+    ASSERT_EQ(count_tracker::updated, 1);
+    ASSERT_EQ(count_tracker::destroyed, 0);
+    ASSERT_EQ(count_tracker::alive(), 1);
+
+    registry.remove<count_tracker>(id);
+
+    ASSERT_EQ(count_tracker::created, 1);
+    ASSERT_EQ(count_tracker::updated, 1);
+    ASSERT_EQ(count_tracker::destroyed, 1);
+    ASSERT_EQ(count_tracker::alive(), 0);
+}
+
+

--- a/test/entt/entity/storage_signals.cpp
+++ b/test/entt/entity/storage_signals.cpp
@@ -18,13 +18,13 @@ struct count_tracker final {
     inline static std::size_t created = 0;
     inline static std::size_t updated = 0;
     inline static std::size_t destroyed = 0;
-    
+
     inline static std::size_t alive() {
         return created - destroyed;
     }
 };
 
-template <typename Type>
+template<typename Type>
 struct StorageSignals: testing::Test {
     using type = Type;
 };
@@ -60,5 +60,3 @@ TYPED_TEST(StorageSignals, AutoSignals) {
     ASSERT_EQ(count_tracker::destroyed, 1);
     ASSERT_EQ(count_tracker::alive(), 0);
 }
-
-


### PR DESCRIPTION
This is the promised implementation for #1165, adding support for binding static functions of components to signals related to their lifetime. 

The functions should be named `on_construct`, `on_update` and `on_destroy`, be `static` to the component and have their signature as `void (entt::basic_registry<Entity, Alloc> &reg, Entity id)` to be considered by the default storage. The functions will be registered only for the specified registry specializations and only if the pool/storage of your component is the default storage. 

A component can implement any of these functions and doesn't need to implement all of them for the feature to work. Also note that these functions will also be available to the named pools of the component as well. If you don't want this behavior, you should have two component types: one exposing the signals and one that doesn't.

Here is an example component incorporating all the supported signals:

```cpp
#include <entt/entity/registry.hpp>
#include <fmt/core.h>

struct dummy final
{
    // the registry here can be a custom one as well (ie. with a custom entity/allocator)
    static void on_construct(entt::registry &reg, entt::entity id)
    {
        fmt::print("Added `dummy` to {}\n", entt::to_entity(id));
    }

    static void on_update(entt::registry &reg, entt::entity id)
    {
        fmt::print("Updated `dummy` of {}\n", entt::to_entity(id));
    }

    static void on_destroy(entt::registry &reg, entt::entity id)
    {
        fmt::print("Removed `dummy` from {}\n", entt::to_entity(id));
    }

    int foo; // just to demonstrate `on_update`
};
```