### PR TITLE
Joining views with storages

### DIFF
--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -164,7 +164,8 @@ class basic_sparse_set {
 
     static constexpr auto max_size = static_cast<std::size_t>(traits_type::to_entity(null));
 
-    [[nodiscard]] auto policy_to_head() const noexcept {
+    // it could be auto but gcc complains and emits a warning due to a false positive
+    [[nodiscard]] std::size_t policy_to_head() const noexcept {
         return static_cast<size_type>(max_size * static_cast<decltype(max_size)>(mode != deletion_policy::swap_only));
     }
 

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -647,10 +647,12 @@ public:
      * @note This function only supports adding one storage, use @ref operator| to join two views instead.
      * @sa operator|
      */
-    template<typename OGet>
-    [[nodiscard]] auto join(OGet &other) const noexcept {
-        return internal::view_pack<basic_view<get_t<Get..., OGet>, exclude_t<Exclude...>>>(
-            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get...>{}, std::index_sequence_for<Exclude...>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
+    template<typename OGet, typename = std::enable_if_t<std::is_lvalue_reference_v<OGet>>>
+    [[nodiscard]] auto join(OGet &&other) const noexcept {
+        using oget_noref = std::remove_reference_t<OGet>;
+
+        return internal::view_pack<basic_view<get_t<Get..., oget_noref>, exclude_t<Exclude...>>>(
+            *this, basic_view<get_t<oget_noref>, exclude_t<>>{other}, std::index_sequence_for<Get...>{}, std::index_sequence_for<Exclude...>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
     }
 
     /**
@@ -1092,10 +1094,12 @@ public:
      * @note This function only supports adding one storage, use @ref operator| to join two views instead.
      * @sa operator|
      */
-    template<typename OGet>
-    [[nodiscard]] auto join(OGet &other) const noexcept {
-        return internal::view_pack<basic_view<get_t<Get, OGet>, exclude_t<>>>(
-            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get>{}, std::index_sequence_for<>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
+    template<typename OGet, typename = std::enable_if_t<std::is_lvalue_reference_v<OGet>>>
+    [[nodiscard]] auto join(OGet &&other) const noexcept {
+        using oget_noref = std::remove_reference_t<OGet>;
+
+        return internal::view_pack<basic_view<get_t<Get, oget_noref>, exclude_t<>>>(
+            *this, basic_view<get_t<oget_noref>, exclude_t<>>{other}, std::index_sequence_for<Get>{}, std::index_sequence_for<>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
     }
 
     /**

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -639,6 +639,21 @@ public:
     }
 
     /**
+     * @brief Attaches a storage to the end of the view for iterating.
+     *
+     * @tparam OGet The type of the storage to attach to the view.
+     * @param other The storage to attach to the view.
+     * @return A new view with the given storage attached.
+     * @note This function only supports adding one storage, use @ref operator| to join two views instead.
+     * @sa operator|
+     */
+    template<typename OGet>
+    [[nodiscard]] auto join(OGet &other) const noexcept {
+        return internal::view_pack<basic_view<get_t<Get..., OGet>, exclude_t<Exclude...>>>(
+            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get...>{}, std::index_sequence_for<Exclude...>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
+    }
+
+    /**
      * @brief Combines two views in a _more specific_ one.
      * @tparam OGet Element list of the view to combine with.
      * @tparam OExclude Filter list of the view to combine with.
@@ -1066,6 +1081,21 @@ public:
             static_assert(Get::storage_policy == deletion_policy::in_place, "Unexpected storage policy");
             return iterable{base_type::begin(), base_type::end()};
         }
+    }
+
+    /**
+     * @brief Attaches a storage to the end of the view for iterating.
+     *
+     * @tparam OGet The type of the storage to attach to the view.
+     * @param other The storage to attach to the view.
+     * @return A new view with the given storage attached.
+     * @note This function only supports adding one storage, use @ref operator| to join two views instead.
+     * @sa operator|
+     */
+    template<typename OGet>
+    [[nodiscard]] auto join(OGet &other) const noexcept {
+        return internal::view_pack<basic_view<get_t<Get, OGet>, exclude_t<>>>(
+            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get>{}, std::index_sequence_for<>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
     }
 
     /**

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -647,12 +647,10 @@ public:
      * @note This function only supports adding one storage, use @ref operator| to join two views instead.
      * @sa operator|
      */
-    template<typename OGet, typename = std::enable_if_t<std::is_lvalue_reference_v<OGet>>>
-    [[nodiscard]] auto join(OGet &&other) const noexcept {
-        using oget_noref = std::remove_reference_t<OGet>;
-
-        return internal::view_pack<basic_view<get_t<Get..., oget_noref>, exclude_t<Exclude...>>>(
-            *this, basic_view<get_t<oget_noref>, exclude_t<>>{other}, std::index_sequence_for<Get...>{}, std::index_sequence_for<Exclude...>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
+    template<typename OGet>
+    [[nodiscard]] auto join(OGet &other) const noexcept {
+        return internal::view_pack<basic_view<get_t<Get..., OGet>, exclude_t<Exclude...>>>(
+            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get...>{}, std::index_sequence_for<Exclude...>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
     }
 
     /**
@@ -1094,12 +1092,10 @@ public:
      * @note This function only supports adding one storage, use @ref operator| to join two views instead.
      * @sa operator|
      */
-    template<typename OGet, typename = std::enable_if_t<std::is_lvalue_reference_v<OGet>>>
-    [[nodiscard]] auto join(OGet &&other) const noexcept {
-        using oget_noref = std::remove_reference_t<OGet>;
-
-        return internal::view_pack<basic_view<get_t<Get, oget_noref>, exclude_t<>>>(
-            *this, basic_view<get_t<oget_noref>, exclude_t<>>{other}, std::index_sequence_for<Get>{}, std::index_sequence_for<>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
+    template<typename OGet>
+    [[nodiscard]] auto join(OGet &other) const noexcept {
+        return internal::view_pack<basic_view<get_t<Get, OGet>, exclude_t<>>>(
+            *this, basic_view<get_t<OGet>, exclude_t<>>{other}, std::index_sequence_for<Get>{}, std::index_sequence_for<>{}, std::index_sequence_for<OGet>{}, std::index_sequence_for<>{});
     }
 
     /**

--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -514,10 +514,7 @@ public:
  * @return A meta factory for the given type.
  */
 template<typename Type>
-[[nodiscard]] auto meta(meta_ctx &ctx) noexcept {
-    auto &&context = internal::meta_context::from(ctx);
-    // make sure the type exists in the context before returning a factory
-    context.value.try_emplace(type_id<Type>().hash(), internal::resolve<Type>(context));
+[[nodiscard]] [[deprecated("use meta_factory directly instead")]] auto meta(meta_ctx &ctx) noexcept {
     return meta_factory<Type>{ctx};
 }
 
@@ -533,7 +530,7 @@ template<typename Type>
  * @return A meta factory for the given type.
  */
 template<typename Type>
-[[nodiscard]] auto meta() noexcept {
+[[nodiscard]] [[deprecated("use meta_factory directly instead")]] auto meta() noexcept {
     return meta<Type>(locator<meta_ctx>::value_or());
 }
 

--- a/test/entt/entity/view.cpp
+++ b/test/entt/entity/view.cpp
@@ -1540,8 +1540,10 @@ TEST(View, Pipe) {
     entt::basic_view view2{std::forward_as_tuple(std::as_const(std::get<0>(storage))), std::forward_as_tuple(std::get<4>(storage))};
     entt::basic_view view3{std::get<2>(storage)};
     entt::basic_view view4{std::get<3>(storage)};
+    entt::basic_view view5{std::get<3>(std::as_const(storage))};
 
     testing::StaticAssertTypeEq<decltype(view1.join(std::get<2>(storage))), decltype(view1 | view3)>();
+    testing::StaticAssertTypeEq<decltype(view1.join(std::get<3>(std::as_const(storage)))), decltype(view1 | view5)>();
 
     testing::StaticAssertTypeEq<entt::basic_view<entt::get_t<entt::storage<int>, const entt::storage<int>>, entt::exclude_t<const entt::storage<double>, entt::storage<float>>>, decltype(view1 | view2)>();
     testing::StaticAssertTypeEq<entt::basic_view<entt::get_t<const entt::storage<int>, entt::storage<int>>, entt::exclude_t<entt::storage<float>, const entt::storage<double>>>, decltype(view2 | view1)>();

--- a/test/entt/entity/view.cpp
+++ b/test/entt/entity/view.cpp
@@ -1541,6 +1541,8 @@ TEST(View, Pipe) {
     entt::basic_view view3{std::get<2>(storage)};
     entt::basic_view view4{std::get<3>(storage)};
 
+    testing::StaticAssertTypeEq<decltype(view1.join(std::get<2>(storage))), decltype(view1 | view3)>();
+
     testing::StaticAssertTypeEq<entt::basic_view<entt::get_t<entt::storage<int>, const entt::storage<int>>, entt::exclude_t<const entt::storage<double>, entt::storage<float>>>, decltype(view1 | view2)>();
     testing::StaticAssertTypeEq<entt::basic_view<entt::get_t<const entt::storage<int>, entt::storage<int>>, entt::exclude_t<entt::storage<float>, const entt::storage<double>>>, decltype(view2 | view1)>();
     testing::StaticAssertTypeEq<decltype((view3 | view2) | view1), decltype(view3 | (view2 | view1))>();


### PR DESCRIPTION
Views are pretty much a core utility of EnTT already and there is good support for many common operations. One of them is joining with other views, especially useful when one view might have named pools. However, the syntax becomes a little noisy when you need to join a view with one storage, which most often is a named `void` storage or a storage out of the registry (from my experience). To do this, we currently have to do something like:
```cpp
entt::storage_for_t<void> dirty_entities;
// ...
auto view = registry.view<C1, const C2>() | entt::basic_view{dirty_entities};
for (auto id : view) {
    // ...
}
```

To address this, I propose to add a `join` function to `basic_view`, which works similarly to the existing `operator|`, except that it only accepts a storage as a parameter instead of a view. So the example before would now look like this:
```cpp
entt::storage_for_t<void> dirty_entities;
// ...
auto view = registry.view<C1, const C2>().join(dirty_entities);
for (auto id : view)
{
    // ...
}
```

Now the function returns a new view, so you can chain `.join()` calls one after another. This is something of preference but I would advise to use `operator|` in that case.