### PR TITLE
Avoid pointless lookups in try_cast

### DIFF
--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -410,7 +410,7 @@ public:
     template<typename Type>
     [[nodiscard]] const Type *try_cast() const {
         const auto &other = type_id<std::remove_cv_t<Type>>();
-        return static_cast<const Type *>(internal::try_cast(internal::meta_context::from(*ctx), node, &other, storage.data()));
+        return static_cast<const Type *>(internal::try_cast(internal::meta_context::from(*ctx), node, other, storage.data()));
     }
 
     /*! @copydoc try_cast */
@@ -420,7 +420,7 @@ public:
             return std::as_const(*this).try_cast<std::remove_const_t<Type>>();
         } else {
             const auto &other = type_id<std::remove_cv_t<Type>>();
-            return static_cast<Type *>(const_cast<void *>(internal::try_cast(internal::meta_context::from(*ctx), node, &other, storage.data())));
+            return static_cast<Type *>(const_cast<void *>(internal::try_cast(internal::meta_context::from(*ctx), node, other, storage.data())));
         }
     }
 
@@ -1280,7 +1280,7 @@ public:
      */
     [[nodiscard]] bool can_cast(const meta_type &other) const noexcept {
         // casting this is UB in all cases but we aren't going to use the resulting pointer, so...
-        return (internal::try_cast(internal::meta_context::from(*ctx), node, other.node.info, this) != nullptr);
+        return (other.node.info != nullptr) && (internal::try_cast(internal::meta_context::from(*ctx), node, *other.node.info, this) != nullptr);
     }
 
     /**

--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -409,8 +409,8 @@ public:
      */
     template<typename Type>
     [[nodiscard]] const Type *try_cast() const {
-        const auto other = internal::resolve<std::remove_cv_t<Type>>(internal::meta_context::from(*ctx));
-        return static_cast<const Type *>(internal::try_cast(internal::meta_context::from(*ctx), node, other, storage.data()));
+        const auto &other = type_id<std::remove_cv_t<Type>>();
+        return static_cast<const Type *>(internal::try_cast(internal::meta_context::from(*ctx), node, &other, storage.data()));
     }
 
     /*! @copydoc try_cast */
@@ -419,8 +419,8 @@ public:
         if constexpr(std::is_const_v<Type>) {
             return std::as_const(*this).try_cast<std::remove_const_t<Type>>();
         } else {
-            const auto other = internal::resolve<std::remove_cv_t<Type>>(internal::meta_context::from(*ctx));
-            return static_cast<Type *>(const_cast<void *>(internal::try_cast(internal::meta_context::from(*ctx), node, other, storage.data())));
+            const auto &other = type_id<std::remove_cv_t<Type>>();
+            return static_cast<Type *>(const_cast<void *>(internal::try_cast(internal::meta_context::from(*ctx), node, &other, storage.data())));
         }
     }
 
@@ -1280,7 +1280,7 @@ public:
      */
     [[nodiscard]] bool can_cast(const meta_type &other) const noexcept {
         // casting this is UB in all cases but we aren't going to use the resulting pointer, so...
-        return (internal::try_cast(internal::meta_context::from(*ctx), node, other.node, this) != nullptr);
+        return (internal::try_cast(internal::meta_context::from(*ctx), node, other.node.info, this) != nullptr);
     }
 
     /**

--- a/src/entt/meta/node.hpp
+++ b/src/entt/meta/node.hpp
@@ -198,8 +198,8 @@ template<typename... Args>
     return value(context);
 }
 
-[[nodiscard]] inline const void *try_cast(const meta_context &context, const meta_type_node &from, const meta_type_node &to, const void *instance) noexcept {
-    if((from.info != nullptr) && (to.info != nullptr) && *from.info == *to.info) {
+[[nodiscard]] inline const void *try_cast(const meta_context &context, const meta_type_node &from, const type_info *to, const void *instance) noexcept {
+    if((from.info != nullptr) && (to != nullptr) && *from.info == *to) {
         return instance;
     }
 

--- a/src/entt/meta/node.hpp
+++ b/src/entt/meta/node.hpp
@@ -198,8 +198,8 @@ template<typename... Args>
     return value(context);
 }
 
-[[nodiscard]] inline const void *try_cast(const meta_context &context, const meta_type_node &from, const type_info *to, const void *instance) noexcept {
-    if((from.info != nullptr) && (to != nullptr) && *from.info == *to) {
+[[nodiscard]] inline const void *try_cast(const meta_context &context, const meta_type_node &from, const type_info &to, const void *instance) noexcept {
+    if((from.info != nullptr) && *from.info == to) {
         return instance;
     }
 


### PR DESCRIPTION
We don't need a complete `meta_type` for the target type of the `try_cast`, but we are OK with the `type_info`.