### PR TITLE
Apply ``consteval`` on appropriate ``basic_hashed_string`` related functions 

### DIFF
--- a/src/entt/config/macro.h
+++ b/src/entt/config/macro.h
@@ -6,6 +6,17 @@
 #define ENTT_STR(arg) #arg
 #define ENTT_XSTR(arg) ENTT_STR(arg)
 
+#define ENTT_CONSTEVAL constexpr
+
+#if __has_include(<version>)
+#    include <version>
+#
+#    if defined(__cpp_consteval)
+#        undef ENTT_CONSTEVAL
+#        define ENTT_CONSTEVAL consteval
+#    endif
+#endif
+
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif

--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -291,7 +291,7 @@ inline namespace literals {
  * @param str The literal without its suffix.
  * @return A properly initialized hashed string.
  */
-[[nodiscard]] constexpr hashed_string operator""_hs(const char *str, std::size_t) noexcept {
+[[nodiscard]] ENTT_CONSTEVAL hashed_string operator""_hs(const char *str, std::size_t) noexcept {
     return hashed_string{str};
 }
 
@@ -300,7 +300,7 @@ inline namespace literals {
  * @param str The literal without its suffix.
  * @return A properly initialized hashed wstring.
  */
-[[nodiscard]] constexpr hashed_wstring operator""_hws(const wchar_t *str, std::size_t) noexcept {
+[[nodiscard]] ENTT_CONSTEVAL hashed_wstring operator""_hws(const wchar_t *str, std::size_t) noexcept {
     return hashed_wstring{str};
 }
 

--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -105,7 +105,7 @@ public:
      */
     template<std::size_t N>
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-    [[nodiscard]] static constexpr hash_type value(const value_type (&str)[N]) noexcept {
+    [[nodiscard]] static ENTT_CONSTEVAL hash_type value(const value_type (&str)[N]) noexcept {
         return basic_hashed_string{str};
     }
 
@@ -137,7 +137,7 @@ public:
      */
     template<std::size_t N>
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-    constexpr basic_hashed_string(const value_type (&str)[N]) noexcept
+    ENTT_CONSTEVAL basic_hashed_string(const value_type (&str)[N]) noexcept
         : base_type{helper({static_cast<const value_type *>(str)})} {}
 
     /**


### PR DESCRIPTION
It's easy to introduce unnecessary runtime-overhead by accident. The documentation even states this:
> No string-to-number conversion will take place at runtime **if used carefully**.

Applying ``consteval`` on the two members, which accept an c-array, seems appropriate as they are obviously intended for compile-time construction.
Making the literals ``entt::literal::_hs`` and ``_hws`` ``consteval`` too, because there is literally no reason to use them at runtime.