### PR TITLE
mixins working with custom protected registry

### DIFF
--- a/src/entt/entity/mixin.hpp
+++ b/src/entt/entity/mixin.hpp
@@ -130,7 +130,12 @@ private:
     }
 
     void bind_any(any value) noexcept final {
-        owner = internal::any_to_owner<registry_type>(value);
+        if(auto *registry = any_cast<owner_type>(&value)) {
+            owner = registry;
+        }
+        else if(auto *base_registry = any_cast<basic_registry_type>(&value)) {
+            owner = reinterpret_cast<owner_type *>(base_registry);
+        }
         underlying_type::bind_any(std::move(value));
     }
 
@@ -386,7 +391,7 @@ public:
     }
 
 private:
-    basic_registry_type *owner;
+    owner_type *owner;
     sigh_type construction;
     sigh_type destruction;
     sigh_type update;
@@ -421,7 +426,12 @@ class basic_reactive_mixin final: public Type {
 
 private:
     void bind_any(any value) noexcept final {
-        owner = internal::any_to_owner<registry_type>(value);
+        if(auto *registry = any_cast<owner_type>(&value)) {
+            owner = registry;
+        }
+        else if(auto *base_registry = any_cast<basic_registry_type>(&value)) {
+            owner = reinterpret_cast<owner_type *>(base_registry);
+        }
         underlying_type::bind_any(std::move(value));
     }
 
@@ -590,7 +600,7 @@ public:
     }
 
 private:
-    basic_registry_type *owner;
+    owner_type *owner;
     container_type conn;
 };
 

--- a/test/common/registry.h
+++ b/test/common/registry.h
@@ -5,8 +5,37 @@
 
 namespace test {
 
+/// Custom registry that exposes a subset of basic registry methods
 template<typename Entity>
-struct basic_custom_registry: entt::basic_registry<Entity> {};
+class basic_custom_registry: protected entt::basic_registry<Entity> {
+    using registry_type = entt::basic_registry<Entity>;
+
+  public:
+    using entity_type = typename registry_type::entity_type;
+    using allocator_type = typename registry_type::allocator_type;
+
+    // Forwarding desired methods to be exposed
+
+    [[nodiscard]] Entity create() { return registry_type::create(); }
+
+    template<typename Type, typename It, typename... Args>
+    void insert(It begin, It end, Args &&... args)
+    {
+        registry_type::template insert<Type>(begin, end, std::forward<Args>(args)...);
+    }
+
+    template<typename Type>
+    decltype(auto) storage(const entt::id_type id = entt::type_hash<Type>::value())
+    {
+        return registry_type::template storage<Type>(id);
+    }
+
+    template<typename Type>
+    decltype(auto) storage(const entt::id_type id = entt::type_hash<Type>::value()) const
+    {
+        return registry_type::template storage<Type>(id);
+    }
+};
 
 } // namespace test
 


### PR DESCRIPTION
Working but.. not-confident-about-the-whole-thing addressing https://github.com/skypjack/entt/issues/1222
The issue is I don't quite like this reinterpret_cast there

What I don't quite understand, is that both the if statements get hit
- when constructing the custom registry, the first if statement gets hit, this is on the `basic_registry` constructor when calling `rebind`. How come any_cast detects the custom registry?
- when creating storages from `assure` (let's say from `.emplace<Component>` from the custom registry, assuming it was exposed), the newly created pool binding hits the second if and the reinterpret_cast is needed.

