### PR TITLE
Fix Wdeprecated-literal-operator warning

### DIFF
--- a/src/entt/core/hashed_string.hpp
+++ b/src/entt/core/hashed_string.hpp
@@ -291,7 +291,7 @@ inline namespace literals {
  * @param str The literal without its suffix.
  * @return A properly initialized hashed string.
  */
-[[nodiscard]] constexpr hashed_string operator"" _hs(const char *str, std::size_t) noexcept {
+[[nodiscard]] constexpr hashed_string operator""_hs(const char *str, std::size_t) noexcept {
     return hashed_string{str};
 }
 
@@ -300,7 +300,7 @@ inline namespace literals {
  * @param str The literal without its suffix.
  * @return A properly initialized hashed wstring.
  */
-[[nodiscard]] constexpr hashed_wstring operator"" _hws(const wchar_t *str, std::size_t) noexcept {
+[[nodiscard]] constexpr hashed_wstring operator""_hws(const wchar_t *str, std::size_t) noexcept {
     return hashed_wstring{str};
 }
 


### PR DESCRIPTION
This warning started showing up in newer versions of clang, since apparently space can not be between "" and the identifier anymore. Fixed that

from gcc (https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html):
```
-Wdeprecated-literal-operator (C++ and Objective-C++ only)

    Warn that the declaration of a user-defined literal operator with a space before the suffix is deprecated. This warning is enabled by default in C++23, or with explicit -Wdeprecated.

    string operator "" _i18n(const char*, std::size_t); // deprecated
    string operator ""_i18n(const char*, std::size_t); // preferred
```