### PR TITLE
Transparent lookup for `dense_map::at`

### DIFF
--- a/src/entt/container/dense_map.hpp
+++ b/src/entt/container/dense_map.hpp
@@ -725,6 +725,24 @@ public:
         return it->second;
     }
 
+    /*! @copydoc at */
+    template<typename Other>
+    [[nodiscard]] std::enable_if_t<is_transparent_v<hasher> && is_transparent_v<key_equal>, std::conditional_t<false, Other, mapped_type const &>>
+    at(const Other &key) const {
+        auto it = find(key);
+        ENTT_ASSERT(it != cend(), "Invalid key");
+        return it->second;
+    }
+
+    /*! @copydoc at */
+    template<typename Other>
+    [[nodiscard]] std::enable_if_t<is_transparent_v<hasher> && is_transparent_v<key_equal>, std::conditional_t<false, Other, mapped_type &>>
+    at(const Other &key) {
+        auto it = find(key);
+        ENTT_ASSERT(it != end(), "Invalid key");
+        return it->second;
+    }
+
     /**
      * @brief Accesses or inserts a given element.
      * @param key A key of an element to find or insert.

--- a/test/entt/container/dense_map.cpp
+++ b/test/entt/container/dense_map.cpp
@@ -66,6 +66,8 @@ TEST(DenseMap, Functionalities) {
 
     map.emplace(0, 0);
 
+    ASSERT_EQ(map.at(0.0), 0);
+
     ASSERT_EQ(map.count(0), 1u);
     ASSERT_EQ(map.count(6.4), 0u);
     ASSERT_EQ(cmap.count(0.0), 1u);

--- a/test/entt/container/dense_map.cpp
+++ b/test/entt/container/dense_map.cpp
@@ -66,7 +66,8 @@ TEST(DenseMap, Functionalities) {
 
     map.emplace(0, 0);
 
-    ASSERT_EQ(map.at(0.0), 0);
+    ASSERT_EQ(map.at(0), 0); // regular key lookup
+    ASSERT_EQ(map.at(0.0), 0); // transparent key lookup
 
     ASSERT_EQ(map.count(0), 1u);
     ASSERT_EQ(map.count(6.4), 0u);


### PR DESCRIPTION
C++26 has this, so why not add it. Does not need any language/library feature.