### PR TITLE
Add missing parentheses like #530

### DIFF
--- a/src/entt/meta/fwd.hpp
+++ b/src/entt/meta/fwd.hpp
@@ -28,7 +28,7 @@ template<typename>
 class meta_factory;
 
 /*! @brief Used to identicate that a sequence container has not a fixed size. */
-inline constexpr std::size_t meta_dynamic_extent = std::numeric_limits<std::size_t>::max();
+inline constexpr std::size_t meta_dynamic_extent = (std::numeric_limits<std::size_t>::max)();
 
 } // namespace entt
 


### PR DESCRIPTION
Adds parentheses around max to prevent conflict with max macro on Windows.