### PR TITLE
Simplify sparse_set::try_emplace iterator computation to improve MSVC codegen

### DIFF
--- a/src/entt/entity/sparse_set.hpp
+++ b/src/entt/entity/sparse_set.hpp
@@ -375,7 +375,7 @@ protected:
             break;
         }
 
-        return --(end() - static_cast<difference_type>(pos));
+    	return iterator(packed, static_cast<typename iterator::difference_type>(pos) + 1);
     }
 
     /*! @brief Forwards variables to derived classes, if any. */


### PR DESCRIPTION
In our application we're often using entity components as single frame signals to communicate between systems. This means in some systems we're adding a lot of entity data each frame. 

When profiling one such system I noticed that a surprising amount of time was being spent in `sparse_set::try_emplace`. Surprisingly 75%+ of that time was spent on the last line returning the iterator.

<img width="732" height="356" alt="Pasted image 20250919214350" src="https://github.com/user-attachments/assets/8687b136-c95f-4fd3-b4ff-e4271a2e5ff5" />

In this code it appears to spill the iterator to the stack 3 times, seemingly once for each operation done on the iterator in the C++ code. Each operation overrides the iterator index value on the stack before reading it back to a register. Because the iterator was partially written to, each time this causes a store-to-load forwarding stall. 

When simplifying the code so that only a single iterator is created directly in code, the generated assembly reduces down to just the few instructions required to write the iterator out to the stack return address once.
<img width="801" height="179" alt="Pasted image 20250919233044" src="https://github.com/user-attachments/assets/6af6ca5a-84d4-42a1-a128-8e60eaa805b0" />

In our application, this change reduced our time spent in `try_emplace` from 33ms per second of test time to around 7ms per second of test time. This test is not fully deterministic and contains a full game scenario simulation so YMMV.

Compiler used: MSVC 19.38.33135 (Default for Unreal Engine 5.6)