### PR TITLE
Fix typo in docs: indefinite

### DIFF
--- a/single_include/entt/entt.hpp
+++ b/single_include/entt/entt.hpp
@@ -85678,7 +85678,7 @@ public:
      *
      * @warning
      * There is no guarantee that the returned handle is valid.<br/>
-     * If it is not, any use will result in indefinite behavior.
+     * If it is not, any use will result in undefined behavior.
      *
      * @param id Unique resource identifier.
      * @return A handle for the given resource.

--- a/src/entt/resource/cache.hpp
+++ b/src/entt/resource/cache.hpp
@@ -308,7 +308,7 @@ public:
      *
      * @warning
      * There is no guarantee that the returned handle is valid.<br/>
-     * If it is not, any use will result in indefinite behavior.
+     * If it is not, any use will result in undefined behavior.
      *
      * @param id Unique resource identifier.
      * @return A handle for the given resource.


### PR DESCRIPTION
Hi,

I think it should be *undefined* instead of *indefinite*.

In `resource_cache::operator[]()`:

https://github.com/skypjack/entt/blob/1333fa53129e7cfded5a9640c4336a254049917b/src/entt/resource/cache.hpp#L310-L312