### PR TITLE
Add explicit bazel rule for cc_library

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:copts.bzl", "COPTS")
 
 package(default_visibility = ["//:__subpackages__"])


### PR DESCRIPTION
Bazel 9 doesn't automatically include cc_library anymore so Entt can't be used in bazel projects that moved to 9 and above.

The fix is to just load the rule. This should be backward compatible and not break anything, as well as unbreak Bazel >= 9.

### Test it!

In an environment with bazel installed, update the `.bazeliskrc` file to point to the latest bazel:

```
USE_BAZEL_VERSION=9.x
```

Then build:

```
bazel build //...

ERROR: Traceback (most recent call last):
	File "~/.cache/bazel/_bazel_lucadv/e19f5b1941291ef8296d7a82044a0f4f/external/+http_archive+entt/src/BUILD.bazel", line 6, column 11, in <toplevel>
		cc_library(
	File "/virtual_builtins_bzl/bazel/exports.bzl", line 40, column 9, in _removed_rule_failure
Error in fail: 
         This rule has been removed from Bazel. Please add a `load()` statement for it.
         This can also be done automatically by running:
         buildifier --lint=fix <path-to-BUILD-or-bzl-file>
        
```

With this PR the step should work just fine.

A few questions:

* Have you ever considered releasing this to the [bazel central registry](https://registry.bazel.build/) so it's easier for Bazel people to include? If not would you be open to the idea (either yourself or being OK with someone else running that effort)?
* Is there a policy for which Bazel version you are targeting to support? Currently the `.bazeliskrc` file points to 6.x that is [EOL](https://bazel.build/release), even 7.x will be EOL by end of the year, but not sure if it points to 6.x because you need to support some project that is on that legacy version?
* Any chance there could be a 3.16.x branch to cherry-pick this fix (and some other backward compatible ones) for folks that can't update to C++-20 yet? If not no worries!