### PR TITLE
Add missing includes to fix layering check

### DIFF
--- a/src/entt/entity/snapshot.hpp
+++ b/src/entt/entity/snapshot.hpp
@@ -3,6 +3,7 @@
 
 #include "../config/config.h"
 #include "../container/dense_map.hpp"
+#include "../core/type_info.hpp"
 #include "../core/type_traits.hpp"
 #include "../stl/concepts.hpp"
 #include "../stl/cstddef.hpp"

--- a/src/entt/meta/template.hpp
+++ b/src/entt/meta/template.hpp
@@ -4,6 +4,7 @@
 #define ENTT_META_TEMPLATE_HPP
 
 #include "../core/type_traits.hpp"
+#include "type_traits.hpp"
 
 namespace entt {
 


### PR DESCRIPTION
I was building this with Bazel + Clang and failed the Clang layering check.
The bad news is that I can't come up with a way to really get an MVP to add a failing test / regression test!

From what I understand we need `core/type_info.hpp` because entt/snaphot.hpp uses `type_hash` here
https://github.com/skypjack/entt/blob/b2338f0b547e08fc12f9658a1c43c8348474c006/src/entt/entity/snapshot.hpp#L92

And `type_hash` is defined in core/type_info.hpp here
https://github.com/skypjack/entt/blob/b2338f0b547e08fc12f9658a1c43c8348474c006/src/entt/core/type_info.hpp#L101

For the meta check, if I understand correctly the template header defines a specialization for the `meta_template_traits` class here
https://github.com/skypjack/entt/blob/b2338f0b547e08fc12f9658a1c43c8348474c006/src/entt/meta/template.hpp#L20

Which is defined here
https://github.com/skypjack/entt/blob/b2338f0b547e08fc12f9658a1c43c8348474c006/src/entt/meta/type_traits.hpp#L13-L14

Hope this makes sense, I tried to AI generate some sort of regression test but that ended up being a significant added code + unit test and seemed ad-hoc for these two headers rather than a fully layering check so I don't know if it's worth for a fairly straightforward change.